### PR TITLE
Fix lookahead struct naming

### DIFF
--- a/MainController/CarController.c
+++ b/MainController/CarController.c
@@ -143,7 +143,7 @@ void CarController_Update(CarController* controller, double dt) {
         printf("Racing algorithm mode. Using racing algorithm for control.\n");
         Vector3 carVelocity = {controller->carState.v_x, controller->carState.v_y, controller->carState.v_z};
         float carSpeed = Vector3_Magnitude(carVelocity);
-        controller->LI = RacingAlgorithm_GetLookaheadIndices(
+        controller->lookaheadIndices = RacingAlgorithm_GetLookaheadIndices(
             controller->nCheckpoints,
             carSpeed,
             &controller->racingConfig);

--- a/MainController/CarController.h
+++ b/MainController/CarController.h
@@ -63,7 +63,7 @@ typedef struct
     // Flag: use racing algorithm (1) or manual input (0).
     int useRacingAlgorithm;
 
-    LookahaedIndicies LI;
+    LookaheadIndices lookaheadIndices;
 
 } CarController;
 

--- a/MainController/main.c
+++ b/MainController/main.c
@@ -97,9 +97,9 @@ int main(int argc, char* argv[]) {
         for (int i = 0; i < controller.nLeftCones; i++) {
             if (i == 0) {
                 SDL_SetRenderDrawColor(g.renderer, 0, 255, 0, 255);
-            } else if (i == controller.LI.speed) {
+            } else if (i == controller.lookaheadIndices.speed) {
                 SDL_SetRenderDrawColor(g.renderer, 255, 255, 0, 255);
-            } else if (i == controller.LI.steer) {
+            } else if (i == controller.lookaheadIndices.steer) {
                 SDL_SetRenderDrawColor(g.renderer, 255, 0, 255, 255);
             } else {
                 SDL_SetRenderDrawColor(g.renderer, 120, 120, 120, 255);
@@ -111,9 +111,9 @@ int main(int argc, char* argv[]) {
         for (int i = 0; i < controller.nRightCones; i++) {
             if (i == 0) {
                 SDL_SetRenderDrawColor(g.renderer, 0, 255, 0, 255);
-            } else if (i == controller.LI.speed) {
+            } else if (i == controller.lookaheadIndices.speed) {
                 SDL_SetRenderDrawColor(g.renderer, 255, 255, 0, 255);
-            } else if (i == controller.LI.steer) {
+            } else if (i == controller.lookaheadIndices.steer) {
                 SDL_SetRenderDrawColor(g.renderer, 255, 0, 255, 255);
             } else {
                 SDL_SetRenderDrawColor(g.renderer, 80, 80, 80, 255);

--- a/PhysicsEngine/Vector.h
+++ b/PhysicsEngine/Vector.h
@@ -12,14 +12,14 @@ extern "C"
         float y;
     } Vector2;
 
-        // LookaheadIndicies strucure.
+        // LookaheadIndices structure.
     typedef struct
     {
         int steer;
         int speed;
         int max;
-        
-    } LookahaedIndicies;
+
+    } LookaheadIndices;
 
     typedef struct
     {

--- a/RacingAlgorithms/RacingAlgorithm.c
+++ b/RacingAlgorithms/RacingAlgorithm.c
@@ -44,12 +44,12 @@ static float CalculateThrottle(float accelerationNeeded) {
     return clamp_float(throttle, -1.0f, 1.0f);
 }
 
-LookahaedIndicies RacingAlgorithm_GetLookaheadIndices(int nCheckpoints, double carVelocity,
+LookaheadIndices RacingAlgorithm_GetLookaheadIndices(int nCheckpoints, double carVelocity,
                                                         const RacingAlgorithmConfig* config) {
 
     if (nCheckpoints <= 0) {
-        LookahaedIndicies LI = {-1, -1, -1};
-        return LI;
+        LookaheadIndices indices = {-1, -1, -1};
+        return indices;
     }
 
     // Compute lookahead distances based on sensitivity.
@@ -62,9 +62,9 @@ LookahaedIndicies RacingAlgorithm_GetLookaheadIndices(int nCheckpoints, double c
     int steeringIndex = (steeringLookaheadDistance < (lookaheadMax + 1)) ? steeringLookaheadDistance : lookaheadMax;
     int speedIndex = (speedLookaheadDistance < (lookaheadMax + 1)) ? speedLookaheadDistance : lookaheadMax;
 
-    LookahaedIndicies LI = {steeringIndex, speedIndex, lookaheadMax};
-    printf("LIObj: %d, %d, %d\n", LI.steer, LI.speed, LI.max);
-    return LI;
+    LookaheadIndices indices = {steeringIndex, speedIndex, lookaheadMax};
+    printf("LIObj: %d, %d, %d\n", indices.steer, indices.speed, indices.max);
+    return indices;
 
 }
 
@@ -77,9 +77,9 @@ float RacingAlgorithm_GetThrottleInput(const Vector3* checkpointPositions, int n
                                          const RacingAlgorithmConfig* config, double dt) {
 
     // Choose the lookahead index for throttle.
-    LookahaedIndicies LI = RacingAlgorithm_GetLookaheadIndices(nCheckpoints, carVelocity, config);
-    int lookaheadIndex = LI.speed;
-    int lookaheadMax = LI.max;
+    LookaheadIndices indices = RacingAlgorithm_GetLookaheadIndices(nCheckpoints, carVelocity, config);
+    int lookaheadIndex = indices.speed;
+    int lookaheadMax = indices.max;
 
     if (lookaheadIndex == -1) {
         return 0.0;
@@ -131,9 +131,9 @@ float RacingAlgorithm_GetSteeringInput(const Vector3* checkpointPositions, int n
                                        const RacingAlgorithmConfig* config, double dt) {
 
     // Choose the lookahead index for throttle.
-    LookahaedIndicies LI = RacingAlgorithm_GetLookaheadIndices(nCheckpoints, carVelocity, config);
-    int lookaheadIndex = LI.steer;
-    int lookaheadMax = LI.max;
+    LookaheadIndices indices = RacingAlgorithm_GetLookaheadIndices(nCheckpoints, carVelocity, config);
+    int lookaheadIndex = indices.steer;
+    int lookaheadMax = indices.max;
 
     if (lookaheadIndex == -1) {
         return 0.0;

--- a/RacingAlgorithms/RacingAlgorithm.h
+++ b/RacingAlgorithms/RacingAlgorithm.h
@@ -34,7 +34,7 @@ extern "C"
                                            double carVelocity, const Transform *carTransform,
                                            const RacingAlgorithmConfig *config, double dt);
 
-    LookahaedIndicies RacingAlgorithm_GetLookaheadIndices(int nCheckpoints, double carVelocity,
+    LookaheadIndices RacingAlgorithm_GetLookaheadIndices(int nCheckpoints, double carVelocity,
                                                 const RacingAlgorithmConfig* config);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- rename `LookahaedIndicies` to `LookaheadIndices`
- update references in the racing algorithm
- use new name in car controller and main loop
- fix related variable names

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68449165a9388324b9004e68c8d4c46f