### PR TITLE
Handle cone collisions with restart option

### DIFF
--- a/MainController/CarController.h
+++ b/MainController/CarController.h
@@ -39,6 +39,9 @@ typedef struct
     int nCheckpoints;
     // For lap detection: when the car "collides" with this checkpoint, a lap is complete.
     Vector3 lastCheckpoint;
+    // Original track data for restarting without regeneration.
+    Vector3 *initialCheckpointPositions;
+    Vector3 initialLastCheckpoint;
 
     // *** New: Cone data ***
     // Arrays for left and right cones and their counts.
@@ -46,6 +49,9 @@ typedef struct
     int nLeftCones;
     Vector3 *rightCones;
     int nRightCones;
+    // Original cone data for restarting without regeneration.
+    Vector3 *initialLeftCones;
+    Vector3 *initialRightCones;
 
     // Simulation timing and distance tracking.
     double totalTime;
@@ -71,10 +77,12 @@ typedef struct
 void CarController_Init(CarController *controller, const char *yamlFilePath);
 
 // Update the simulation by dt seconds.
-void CarController_Update(CarController *controller, double dt);
+// Returns 1 if a cone collision occurred, 0 otherwise.
+int CarController_Update(CarController *controller, double dt);
 
-// Reset the car state and regenerate track.
-void CarController_Reset(CarController *controller);
+// Reset the car state. If regenerateTrack is non-zero a new track is
+// generated; otherwise the original track is restored.
+void CarController_Reset(CarController *controller, int regenerateTrack);
 
 #ifdef __cplusplus
 }

--- a/MainController/main.c
+++ b/MainController/main.c
@@ -27,6 +27,10 @@ int main(int argc, char* argv[]) {
     }
     printf("Using dt = %.4f seconds\n", dt);
 
+    // Control whether a new track is generated when restarting after a cone
+    // collision. Set to 1 for a new track, 0 to reuse the existing track.
+    int regenerateTrackOnRestart = 0;
+
     // Initialize keyboard input.
     //KeyboardInputHandler_Init();
 
@@ -75,7 +79,12 @@ int main(int argc, char* argv[]) {
         }
         */
 
-        CarController_Update(&controller, dt);
+        if (CarController_Update(&controller, dt)) {
+            printf("Restarting simulation\n");
+            CarController_Reset(&controller, regenerateTrackOnRestart);
+            totalTime = 0.0;
+            continue;
+        }
         
         // Log current state to CSV.
         fprintf(csvFile, "%.2f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f\n",


### PR DESCRIPTION
## Summary
- Detect collisions with left or right cones and abort current run
- Add reset logic to optionally regenerate the track or reuse the existing layout
- Allow main loop to restart simulation after cone impact with a configurable flag

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: undefined references in math/YAML linking)*

------
https://chatgpt.com/codex/tasks/task_e_689f454bea848324b3da35dd04897727