### PR TITLE
Introduce World simulation layer and integrate into build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include_directories(${CMAKE_SOURCE_DIR}/tools/Graphics)
 include_directories(${CMAKE_SOURCE_DIR}/tools)
 include_directories(${CMAKE_SOURCE_DIR}/MainController)
+include_directories(${CMAKE_SOURCE_DIR}/sim)
 include_directories(${CMAKE_SOURCE_DIR}/sim/track)
 include_directories(${CMAKE_SOURCE_DIR}/common/physics)
 include_directories(${CMAKE_SOURCE_DIR}/planning)
@@ -77,6 +78,7 @@ target_link_libraries(PathLogicTest Eigen3::Eigen)
 
 # Collect source files.
 file(GLOB MAINCONTROLLER_SOURCES "${CMAKE_SOURCE_DIR}/MainController/*.c" "${CMAKE_SOURCE_DIR}/MainController/*.cpp")
+file(GLOB WORLD_SOURCES "${CMAKE_SOURCE_DIR}/sim/*.cpp")
 
 #Remove test.c from the list of source files
 file(GLOB PATHLOGIC_SOURCES "${CMAKE_SOURCE_DIR}/sim/track/*.cpp")
@@ -96,6 +98,7 @@ set(SIMULATION_SOURCE_FINAL "${CMAKE_SOURCE_DIR}/MainController/main.cpp")
 add_executable(MainController
     ${SIMULATION_SOURCE_FINAL}
     ${MAINCONTROLLER_SOURCES}
+    ${WORLD_SOURCES}
     ${PATHLOGIC_SOURCES}
     ${PHYSICS_SOURCES}
     ${RACING_SOURCES}
@@ -114,12 +117,12 @@ add_executable(ThrottleTest ${THROTTLE_TEST_SOURCE}
                 ${RACING_SOURCES}
                 ${PHYSICS_SOURCES}
             )
-target_link_libraries(ThrottleTest Eigen3::Eigen)
+target_link_libraries(ThrottleTest Eigen3::Eigen m)
 
 set(STEERING_TEST_SOURCE "${CMAKE_SOURCE_DIR}/planning/test/TestSteering.c")
 add_executable(SteeringTest ${STEERING_TEST_SOURCE}
                 ${RACING_SOURCES}
                 ${PHYSICS_SOURCES}
             )
-target_link_libraries(SteeringTest Eigen3::Eigen)
+target_link_libraries(SteeringTest Eigen3::Eigen m)
                      

--- a/sim/World.cpp
+++ b/sim/World.cpp
@@ -1,0 +1,260 @@
+#include "World.hpp"
+#include <cstdio>
+#include <cmath>
+
+static Vector3 transformToVector3(const Transform& t) {
+    return {t.position.x, t.position.y, t.position.z};
+}
+
+void World::init(const char* yamlFilePath) {
+    // Generate track data
+    PathConfig pathConfig;
+    int nPoints = pathConfig.resolution;
+    PathGenerator pathGen(pathConfig);
+    PathResult path = pathGen.generatePath(nPoints);
+    TrackGenerator trackGen;
+    TrackResult track = trackGen.generateTrack(pathConfig, path);
+
+    // Store checkpoint and cone data
+    checkpointPositions.clear();
+    leftCones.clear();
+    rightCones.clear();
+    for (const auto& cp : track.checkpoints) {
+        checkpointPositions.push_back(transformToVector3(cp));
+    }
+    for (const auto& lc : track.leftCones) {
+        leftCones.push_back(transformToVector3(lc));
+    }
+    for (const auto& rc : track.rightCones) {
+        rightCones.push_back(transformToVector3(rc));
+    }
+    if (!track.checkpoints.empty()) {
+        lastCheckpoint = transformToVector3(track.checkpoints.back());
+    } else {
+        lastCheckpoint = {0, 0, 0};
+    }
+
+    // Initialize simulation variables
+    totalTime = 0.0;
+    totalDistance = 0.0;
+    lapCount = 0;
+    deltaTime = 0.0;
+
+    // Controller configuration
+    config.collisionThreshold = 2.5f;
+    config.coneCollisionThreshold = 0.5f;
+    config.lapCompletionThreshold = 0.1f;
+
+    // Use racing algorithm by default
+    useRacingAlgorithm = 1;
+
+    // Regenerate track after cone collision
+    regenTrack = 1;
+
+    // Racing algorithm configuration
+    racingConfig.speedLookAheadSensitivity = 0.7f;
+    racingConfig.steeringLookAheadSensitivity = 0.1f;
+    racingConfig.accelerationFactor = 0.002f;
+
+    // Make sure car starts on the track
+    float startX = checkpointPositions[0].x;
+    float startZ = checkpointPositions[0].z;
+    float nextX = checkpointPositions[10].x;
+    float nextZ = checkpointPositions[10].z;
+    Vector2 zeroVector{0,0};
+    Vector2 startVector{nextX - startX, nextZ - startZ};
+    float startYaw = Vector2_SignedAngle(zeroVector, startVector) * M_PI/180.0f;
+
+    // Initialize car model, state, and transform
+    VehicleParam vp = VehicleParam::loadFromFile(yamlFilePath);
+    carModel = DynamicBicycle(vp);
+    carInput = VehicleInput(0.0, 0.0, 0.0);
+    carState = VehicleState(Eigen::Vector3d(startX, startZ, 0.0), startYaw,
+                            Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(),
+                            Eigen::Vector3d::Zero());
+    carTransform.position.x = static_cast<float>(carState.position.x());
+    carTransform.position.y = 0.5f;
+    carTransform.position.z = static_cast<float>(carState.position.y());
+    carTransform.yaw = static_cast<float>(carState.yaw);
+}
+
+void World::update(double dt) {
+    deltaTime = dt;
+    totalTime += dt;
+
+    if (checkpointPositions.empty()) {
+        std::printf("No checkpoints available. Resetting simulation.\n");
+        reset();
+        return;
+    }
+
+    if (useRacingAlgorithm) {
+        Vector3 carVelocity{static_cast<float>(carState.velocity.x()),
+                            static_cast<float>(carState.velocity.y()),
+                            static_cast<float>(carState.velocity.z())};
+        float carSpeed = Vector3_Magnitude(carVelocity);
+        lookaheadIndices = RacingAlgorithm_GetLookaheadIndices(
+            static_cast<int>(checkpointPositions.size()), carSpeed, &racingConfig);
+        throttleInput = RacingAlgorithm_GetThrottleInput(
+            checkpointPositions.data(), static_cast<int>(checkpointPositions.size()),
+            carSpeed, &carTransform, &racingConfig, dt);
+        steeringAngle = RacingAlgorithm_GetSteeringInput(
+            checkpointPositions.data(), static_cast<int>(checkpointPositions.size()),
+            carSpeed, &carTransform, &racingConfig, dt);
+        std::printf("THROTTLE: %f, ANGLE: %f\n", throttleInput, steeringAngle);
+    }
+
+    carInput.acc = throttleInput;
+    carInput.delta = steeringAngle;
+
+    carModel.updateState(carState, carInput, dt);
+
+    carTransform.position.x = static_cast<float>(carState.position.x());
+    carTransform.position.z = static_cast<float>(carState.position.y());
+    carTransform.yaw = static_cast<float>(carState.yaw);
+
+    totalDistance += carState.velocity.x() * dt;
+
+    if (!detectCollisions()) {
+        return;
+    }
+
+    telemetry();
+}
+
+bool World::detectCollisions() {
+    float dx = carTransform.position.x - checkpointPositions[0].x;
+    float dz = carTransform.position.z - checkpointPositions[0].z;
+    float distToNext = std::sqrt(dx * dx + dz * dz);
+    if (distToNext < config.collisionThreshold) {
+        moveNextCheckpointToLast();
+    }
+    std::printf("Next Checkpoint: (%f, %f)\n", checkpointPositions[0].x, checkpointPositions[0].z);
+
+    dx = carTransform.position.x - lastCheckpoint.x;
+    dz = carTransform.position.z - lastCheckpoint.z;
+    float distToLast = std::sqrt(dx * dx + dz * dz);
+    if (distToLast < config.lapCompletionThreshold) {
+        if (lapCount > 0) {
+            std::printf("Lap Completed. Time: %.2f s, Distance: %.2f, Lap: %d\n",
+                       totalTime, totalDistance, lapCount);
+        }
+        lapCount++;
+        totalTime = 0.0;
+        totalDistance = 0.0;
+    }
+
+    for (const auto& cone : leftCones) {
+        float cdx = carTransform.position.x - cone.x;
+        float cdz = carTransform.position.z - cone.z;
+        float cdist = std::sqrt(cdx * cdx + cdz * cdz);
+        if (cdist < config.coneCollisionThreshold) {
+            std::printf("Collision with a cone detected.\n");
+            reset();
+            return false;
+        }
+    }
+    for (const auto& cone : rightCones) {
+        float cdx = carTransform.position.x - cone.x;
+        float cdz = carTransform.position.z - cone.z;
+        float cdist = std::sqrt(cdx * cdx + cdz * cdz);
+        if (cdist < config.coneCollisionThreshold) {
+            std::printf("Collision with a cone detected.\n");
+            reset();
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void World::telemetry() const {
+    Telemetry_Update(carState, carTransform, totalTime, totalDistance, lapCount);
+}
+
+void World::moveNextCheckpointToLast() {
+    if (!checkpointPositions.empty()) {
+        std::rotate(checkpointPositions.begin(), checkpointPositions.begin() + 1, checkpointPositions.end());
+    }
+    if (!leftCones.empty()) {
+        std::rotate(leftCones.begin(), leftCones.begin() + 1, leftCones.end());
+    }
+    if (!rightCones.empty()) {
+        std::rotate(rightCones.begin(), rightCones.begin() + 1, rightCones.end());
+    }
+}
+
+void World::reset() {
+    if (regenTrack) {
+        totalTime = 0.0;
+        totalDistance = 0.0;
+
+        std::printf("Regenerating track due to cone collision.\n");
+
+        PathConfig pathConfig;
+        int nPoints = pathConfig.resolution;
+        PathGenerator pathGen(pathConfig);
+        PathResult path = pathGen.generatePath(nPoints);
+        TrackGenerator trackGen;
+        TrackResult track = trackGen.generateTrack(pathConfig, path);
+
+        checkpointPositions.clear();
+        leftCones.clear();
+        rightCones.clear();
+        for (const auto& cp : track.checkpoints) {
+            checkpointPositions.push_back(transformToVector3(cp));
+        }
+        for (const auto& lc : track.leftCones) {
+            leftCones.push_back(transformToVector3(lc));
+        }
+        for (const auto& rc : track.rightCones) {
+            rightCones.push_back(transformToVector3(rc));
+        }
+        if (!track.checkpoints.empty()) {
+            lastCheckpoint = transformToVector3(track.checkpoints.back());
+        } else {
+            lastCheckpoint = {0,0,0};
+        }
+
+        carInput = VehicleInput(0.0, 0.0, 0.0);
+
+        float startX = checkpointPositions[0].x;
+        float startZ = checkpointPositions[0].z;
+        float nextX = checkpointPositions[10].x;
+        float nextZ = checkpointPositions[10].z;
+        Vector2 zeroVector{0,0};
+        Vector2 startVector{nextX - startX, nextZ - startZ};
+        float startYaw = Vector2_SignedAngle(zeroVector, startVector) * M_PI/180.0f;
+
+        carState = VehicleState(Eigen::Vector3d(startX, startZ, 0.0), startYaw,
+                                Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(),
+                                Eigen::Vector3d::Zero());
+        carTransform.position.x = static_cast<float>(carState.position.x());
+        carTransform.position.y = 0.5f;
+        carTransform.position.z = static_cast<float>(carState.position.y());
+        carTransform.yaw = static_cast<float>(carState.yaw);
+    } else {
+        carInput = VehicleInput(0.0, 0.0, 0.0);
+        totalTime = 0.0;
+        totalDistance = 0.0;
+
+        std::printf("Resetting simulation without regenerating track.\n");
+
+        float startX = checkpointPositions[0].x;
+        float startZ = checkpointPositions[0].z;
+        float nextX = checkpointPositions[10].x;
+        float nextZ = checkpointPositions[10].z;
+        Vector2 zeroVector{0,0};
+        Vector2 startVector{nextX - startX, nextZ - startZ};
+        float startYaw = Vector2_SignedAngle(zeroVector, startVector) * M_PI/180.0f;
+
+        carState = VehicleState(Eigen::Vector3d(startX, startZ, 0.0), startYaw,
+                                Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(),
+                                Eigen::Vector3d::Zero());
+        carTransform.position.x = static_cast<float>(carState.position.x());
+        carTransform.position.y = 0.5f;
+        carTransform.position.z = static_cast<float>(carState.position.y());
+        carTransform.yaw = static_cast<float>(carState.yaw);
+    }
+}
+

--- a/sim/World.hpp
+++ b/sim/World.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <vector>
+#include <Eigen/Dense>
+#include "DynamicBicycle.hpp"
+#include "VehicleState.hpp"
+#include "VehicleInput.hpp"
+#include "Telemetry.hpp"
+#include "RacingAlgorithm.h"
+#include "Transform.h"
+#include "Vector.h"
+#include "PathConfig.hpp"
+#include "PathGenerator.hpp"
+#include "TrackGenerator.hpp"
+
+class World {
+public:
+    World() = default;
+
+    // Initialize the world with vehicle parameters and generate track.
+    void init(const char* yamlFilePath);
+
+    // Update simulation by dt seconds.
+    void update(double dt);
+
+    // Detect collisions with checkpoints and cones. Returns false if a reset occurred.
+    bool detectCollisions();
+
+    // Output telemetry information.
+    void telemetry() const;
+
+    // Public control parameters for manual control or algorithms.
+    float steeringAngle{0.0f};
+    float throttleInput{0.0f};
+    int useRacingAlgorithm{1};
+    int regenTrack{1};
+
+private:
+    void moveNextCheckpointToLast();
+    void reset();
+
+    DynamicBicycle carModel{VehicleParam()};
+    VehicleState carState{Eigen::Vector3d::Zero(), 0.0,
+                          Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(),
+                          Eigen::Vector3d::Zero()};
+    VehicleInput carInput{0.0, 0.0, 0.0};
+    Transform carTransform{};
+
+    std::vector<Vector3> checkpointPositions{};
+    std::vector<Vector3> leftCones{};
+    std::vector<Vector3> rightCones{};
+    Vector3 lastCheckpoint{0.0f, 0.0f, 0.0f};
+
+    struct Config {
+        float collisionThreshold{2.5f};
+        float coneCollisionThreshold{0.5f};
+        float lapCompletionThreshold{0.1f};
+    } config{};
+
+    RacingAlgorithmConfig racingConfig{};
+    LookaheadIndices lookaheadIndices{};
+
+    double totalTime{0.0};
+    double deltaTime{0.0};
+    double totalDistance{0.0};
+    int lapCount{0};
+};
+


### PR DESCRIPTION
## Summary
- Add `World` class in `sim` to encapsulate vehicle model, track, collision checks and telemetry
- Include new world sources in build and expose `sim` headers
- Link test executables with math library to allow successful build

## Testing
- `cmake ..`
- `make -j2`


------
https://chatgpt.com/codex/tasks/task_e_68c45ecb16c083249ef653ebe7960487