### PR TITLE
Implement shared monotonic clock and time propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(PROJ_INCLUDE_DIRS
   "${CMAKE_SOURCE_DIR}/sim"
   "${CMAKE_SOURCE_DIR}/sim/track"
   "${CMAKE_SOURCE_DIR}/common/physics"
+  "${CMAKE_SOURCE_DIR}/common/time"
   "${CMAKE_SOURCE_DIR}/planning"
   "${CMAKE_SOURCE_DIR}/sim/vehicle"
   "${CMAKE_SOURCE_DIR}/common/telemetry"
@@ -112,6 +113,7 @@ file(GLOB TELEMETRY_SOURCES
   "${CMAKE_SOURCE_DIR}/common/telemetry/*.c"
   "${CMAKE_SOURCE_DIR}/common/telemetry/*.cpp"
 )
+file(GLOB TIME_SOURCES "${CMAKE_SOURCE_DIR}/common/time/*.cpp")
 
 # Remove test files from app builds
 list(REMOVE_ITEM PATH_LOGIC_SOURCES
@@ -155,6 +157,7 @@ add_executable(MainController
   ${RACING_SOURCES}
   ${SIMULATIONMODELS_SOURCES}
   ${TELEMETRY_SOURCES}
+  ${TIME_SOURCES}
   ${KEY_SOURCES}
   ${GRAPHICS_SOURCES}
   ${GRAPHICS_H_SOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_definitions(-DSDL_MAIN_HANDLED)
 # Project headers (local)
 # ------------------------------------------------------------------------------
 set(PROJ_INCLUDE_DIRS
+  "${CMAKE_SOURCE_DIR}"
   "${CMAKE_SOURCE_DIR}/tools/Graphics"
   "${CMAKE_SOURCE_DIR}/tools"
   "${CMAKE_SOURCE_DIR}/MainController"

--- a/MainController/CarController.hpp
+++ b/MainController/CarController.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include "DynamicBicycle.hpp"  // vehicle model
 #include "VehicleState.hpp"
 #include "VehicleInput.hpp"
@@ -43,6 +44,9 @@ struct CarController {
     // Simulation timing and distance tracking.
     double totalTime{0.0};
     double deltaTime{0.0};
+    uint64_t startTimeNs{0};
+    uint64_t lapStartTimeNs{0};
+    uint64_t lastTickNs{0};
     double totalDistance{0.0};
     int lapCount{0};
 
@@ -66,8 +70,8 @@ struct CarController {
 void CarController_Init(CarController* controller, const char* yamlFilePath);
 
 // Update the simulation by dt seconds.
-void CarController_Update(CarController* controller, double dt);
+void CarController_Update(CarController* controller, double dt, uint64_t now_ns);
 
 // Reset the car state and regenerate track.
-void CarController_Reset(CarController* controller);
+void CarController_Reset(CarController* controller, uint64_t now_ns);
 

--- a/MainController/main.cpp
+++ b/MainController/main.cpp
@@ -3,9 +3,11 @@
 #include <ctime>
 #include <cmath>
 #include "fsai_clock.h"
+#include "common/types.h"
 #include "CarController.hpp"
-#include "KeyboardInputHandler.h"
 #include "Graphics.h"
+#include "KeyboardInputHandler.h"
+#include "budget.h"
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -39,6 +41,18 @@ int main(int argc, char* argv[]) {
     const uint64_t step_ns = fsai_clock_from_seconds(dt);
     const double step_seconds = fsai_clock_to_seconds(step_ns);
 
+    fsai_budget_init();
+    // Budgets derived from the FS-AI v1.1 contract: render @60 Hz (~16.6 ms),
+    // vision ≤20 ms, planner+controller sub-5 ms, CAN within ~2 ms of stamping.
+    fsai_budget_configure(FSAI_BUDGET_SUBSYSTEM_SIMULATION, "Simulation Renderer", fsai_clock_from_seconds(1.0 / 60.0));
+    fsai_budget_configure(FSAI_BUDGET_SUBSYSTEM_CONTROL, "Planner + Controller", fsai_clock_from_seconds(0.005));
+    fsai_budget_configure(FSAI_BUDGET_SUBSYSTEM_VISION, "Vision Pipeline", fsai_clock_from_seconds(0.020));
+    fsai_budget_configure(FSAI_BUDGET_SUBSYSTEM_CAN, "CAN Dispatch", fsai_clock_from_seconds(0.002));
+    fsai_budget_mark_unimplemented(FSAI_BUDGET_SUBSYSTEM_VISION,
+                                   "Vision pipeline not yet integrated; timing scaffold active.");
+    fsai_budget_mark_unimplemented(FSAI_BUDGET_SUBSYSTEM_CAN,
+                                   "CAN transport not wired; pending hardware integration.");
+
     // Initialize the car controller.
     CarController controller;
     CarController_Init(&controller, "../sim/vehicle/Configs/configDry.yaml");
@@ -64,6 +78,7 @@ int main(int argc, char* argv[]) {
         std::fprintf(stderr, "Graphics_Init failed\n");
         std::exit(EXIT_FAILURE);
     }
+    size_t frame_counter = 0;
     while (1) {
         // Poll SDL events to keep window responsive.
         SDL_Event event;
@@ -84,7 +99,10 @@ int main(int argc, char* argv[]) {
         */
 
         const uint64_t now_ns = fsai_clock_advance(step_ns);
-        CarController_Update(&controller, step_seconds, now_ns);
+        {
+            fsai::time::ControlStageTimer control_timer("control_tick");
+            CarController_Update(&controller, step_seconds, now_ns);
+        }
         const double sim_time_s = fsai_clock_to_seconds(now_ns - controller.startTimeNs);
 
         // Log current state to CSV.
@@ -98,51 +116,59 @@ int main(int argc, char* argv[]) {
                      sim_time_s, controller.throttleInput, controller.steeringAngle);
 
         // --- Graphics Update ---
-        Graphics_Clear(&g);
-        Graphics_DrawGrid(&g, 50);  // Draw grid with 50-pixel spacing.
-        SDL_SetRenderDrawColor(g.renderer, 200, 0, 200, 255);
-        Graphics_DrawFilledCircle(&g, controller.checkpointPositions[0].x*SCALE + g.width/2, controller.checkpointPositions[0].z*SCALE + g.height/2, 1.5*SCALE);
+        {
+            fsai::time::SimulationStageTimer render_timer("renderer");
+            Graphics_Clear(&g);
+            Graphics_DrawGrid(&g, 50);  // Draw grid with 50-pixel spacing.
+            SDL_SetRenderDrawColor(g.renderer, 200, 0, 200, 255);
+            Graphics_DrawFilledCircle(&g, controller.checkpointPositions[0].x*SCALE + g.width/2, controller.checkpointPositions[0].z*SCALE + g.height/2, 1.5*SCALE);
 
-        // Draw cones as black circles.
-        for (int i = 0; i < controller.nLeftCones; i++) {
-            if (i == 0) {
-                SDL_SetRenderDrawColor(g.renderer, 0, 255, 0, 255);
-            } else if (i == controller.lookaheadIndices.speed) {
-                SDL_SetRenderDrawColor(g.renderer, 255, 255, 0, 255);
-            } else if (i == controller.lookaheadIndices.steer) {
-                SDL_SetRenderDrawColor(g.renderer, 255, 0, 255, 255);
-            } else {
-                SDL_SetRenderDrawColor(g.renderer, 120, 120, 120, 255);
+            // Draw cones as black circles.
+            for (int i = 0; i < controller.nLeftCones; i++) {
+                if (i == 0) {
+                    SDL_SetRenderDrawColor(g.renderer, 0, 255, 0, 255);
+                } else if (i == controller.lookaheadIndices.speed) {
+                    SDL_SetRenderDrawColor(g.renderer, 255, 255, 0, 255);
+                } else if (i == controller.lookaheadIndices.steer) {
+                    SDL_SetRenderDrawColor(g.renderer, 255, 0, 255, 255);
+                } else {
+                    SDL_SetRenderDrawColor(g.renderer, 120, 120, 120, 255);
+                }
+                int coneX = (int)(controller.leftCones[i].x*SCALE + g.width/2);
+                int coneY = (int)(controller.leftCones[i].z*SCALE + g.height/2);
+                Graphics_DrawFilledCircle(&g, coneX, coneY, SCALE);
             }
-            int coneX = (int)(controller.leftCones[i].x*SCALE + g.width/2);
-            int coneY = (int)(controller.leftCones[i].z*SCALE + g.height/2);
-            Graphics_DrawFilledCircle(&g, coneX, coneY, SCALE);
-        }
-        for (int i = 0; i < controller.nRightCones; i++) {
-            if (i == 0) {
-                SDL_SetRenderDrawColor(g.renderer, 0, 255, 0, 255);
-            } else if (i == controller.lookaheadIndices.speed) {
-                SDL_SetRenderDrawColor(g.renderer, 255, 255, 0, 255);
-            } else if (i == controller.lookaheadIndices.steer) {
-                SDL_SetRenderDrawColor(g.renderer, 255, 0, 255, 255);
-            } else {
-                SDL_SetRenderDrawColor(g.renderer, 80, 80, 80, 255);
+            for (int i = 0; i < controller.nRightCones; i++) {
+                if (i == 0) {
+                    SDL_SetRenderDrawColor(g.renderer, 0, 255, 0, 255);
+                } else if (i == controller.lookaheadIndices.speed) {
+                    SDL_SetRenderDrawColor(g.renderer, 255, 255, 0, 255);
+                } else if (i == controller.lookaheadIndices.steer) {
+                    SDL_SetRenderDrawColor(g.renderer, 255, 0, 255, 255);
+                } else {
+                    SDL_SetRenderDrawColor(g.renderer, 80, 80, 80, 255);
+                }
+                int coneX = (int)(controller.rightCones[i].x*SCALE + g.width/2);
+                int coneY = (int)(controller.rightCones[i].z*SCALE + g.height/2);
+                Graphics_DrawFilledCircle(&g, coneX, coneY, SCALE);
             }
-            int coneX = (int)(controller.rightCones[i].x*SCALE + g.width/2);
-            int coneY = (int)(controller.rightCones[i].z*SCALE + g.height/2);
-            Graphics_DrawFilledCircle(&g, coneX, coneY, SCALE);
-        }
 
-        // Map simulation coordinates to screen coordinates.
-        float carScreenX = static_cast<float>(controller.carState.position.x())*SCALE + g.width / 2.0f;
-        float carScreenY = static_cast<float>(controller.carState.position.y())*SCALE + g.height / 2.0f;
-        float carRadius = 2.0f*SCALE;
-        float carYaw = static_cast<float>(controller.carState.yaw);
-        // Draw the car using Graphics_DrawCar.
-        Graphics_DrawCar(&g, carScreenX, carScreenY, carRadius, carYaw);
-        Graphics_Present(&g);
+            // Map simulation coordinates to screen coordinates.
+            float carScreenX = static_cast<float>(controller.carState.position.x())*SCALE + g.width / 2.0f;
+            float carScreenY = static_cast<float>(controller.carState.position.y())*SCALE + g.height / 2.0f;
+            float carRadius = 2.0f*SCALE;
+            float carYaw = static_cast<float>(controller.carState.yaw);
+            // Draw the car using Graphics_DrawCar.
+            Graphics_DrawCar(&g, carScreenX, carScreenY, carRadius, carYaw);
+            Graphics_Present(&g);
+        }
 
         SDL_Delay((Uint32)(step_seconds * 1000.0));
+
+        frame_counter++;
+        if (frame_counter % 120 == 0) {
+            fsai_budget_report_all();
+        }
     }
 
 exit_loop:
@@ -150,6 +176,8 @@ exit_loop:
     fclose(csvFile_ra);
     KeyboardInputHandler_Restore();
     Graphics_Cleanup(&g);
+
+    fsai_budget_report_all();
 
     std::printf("Simulation complete. Car state log saved to CarStateLog.csv\n");
     return EXIT_SUCCESS;

--- a/common/telemetry/Telemetry.cpp
+++ b/common/telemetry/Telemetry.cpp
@@ -1,9 +1,13 @@
 #include "Telemetry.hpp"
 #include <cstdio>
+#include "fsai_clock.h"
 
 void Telemetry_Update(const VehicleState& carState, const Transform& carTransform,
-                      double totalTime, double totalDistance, int lapCount) {
-    std::printf("Time: %.2f s, Distance: %.2f, Lap: %d\n", totalTime, totalDistance, lapCount);
+                      uint64_t simTimeNs, double lapTimeSeconds,
+                      double totalDistance, int lapCount) {
+    const double simTimeSeconds = fsai_clock_to_seconds(simTimeNs);
+    std::printf("Sim Time: %.3f s, Lap Time: %.2f s, Distance: %.2f, Lap: %d\n",
+                simTimeSeconds, lapTimeSeconds, totalDistance, lapCount);
     std::printf("Car State -> x: %.2f, y: %.2f, yaw: %.2f, v_x: %.2f\n",
                 carState.position.x(), carState.position.y(), carState.yaw, carState.velocity.x());
     std::printf("Car Transform -> Pos: (%.2f, %.2f, %.2f), Yaw: %.2f\n",

--- a/common/telemetry/Telemetry.hpp
+++ b/common/telemetry/Telemetry.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <cstdint>
 #include "VehicleState.hpp"
 #include "Transform.h"
 
 // Prints simulation telemetry to the terminal.
 void Telemetry_Update(const VehicleState& carState, const Transform& carTransform,
-                      double totalTime, double totalDistance, int lapCount);
+                      uint64_t simTimeNs, double lapTimeSeconds,
+                      double totalDistance, int lapCount);
 

--- a/common/time/budget.cpp
+++ b/common/time/budget.cpp
@@ -1,0 +1,151 @@
+#include "budget.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "fsai_clock.h"
+
+typedef struct fsai_budget_entry {
+    const char* name;
+    uint64_t budget_ns;
+    uint64_t last_duration_ns;
+    uint64_t worst_duration_ns;
+    uint64_t total_duration_ns;
+    uint64_t sample_count;
+    int configured;
+    int note_printed;
+    const char* unimplemented_note;
+} fsai_budget_entry;
+
+static fsai_budget_entry g_budget_entries[FSAI_BUDGET_SUBSYSTEM_COUNT];
+static int g_budget_enabled = 1;
+
+static int fsai_budget_valid_subsystem(fsai_budget_subsystem subsystem) {
+    return subsystem >= 0 && subsystem < FSAI_BUDGET_SUBSYSTEM_COUNT;
+}
+
+void fsai_budget_init(void) {
+    memset(g_budget_entries, 0, sizeof(g_budget_entries));
+    g_budget_enabled = 1;
+}
+
+void fsai_budget_set_enabled(int enabled) {
+    g_budget_enabled = enabled ? 1 : 0;
+}
+
+void fsai_budget_configure(fsai_budget_subsystem subsystem, const char* name, uint64_t budget_ns) {
+    if (!fsai_budget_valid_subsystem(subsystem)) {
+        return;
+    }
+    fsai_budget_entry* entry = &g_budget_entries[subsystem];
+    entry->name = name;
+    entry->budget_ns = budget_ns;
+    entry->configured = 1;
+    entry->last_duration_ns = 0;
+    entry->worst_duration_ns = 0;
+    entry->total_duration_ns = 0;
+    entry->sample_count = 0;
+    entry->note_printed = 0;
+}
+
+void fsai_budget_mark_unimplemented(fsai_budget_subsystem subsystem, const char* note) {
+    if (!fsai_budget_valid_subsystem(subsystem)) {
+        return;
+    }
+    fsai_budget_entry* entry = &g_budget_entries[subsystem];
+    if (!entry->configured || entry->note_printed) {
+        return;
+    }
+    entry->unimplemented_note = note;
+    entry->note_printed = 1;
+    if (g_budget_enabled) {
+        printf("[Timing][%s] Note: %s\n", entry->name ? entry->name : "<unnamed>", note);
+    }
+}
+
+static void fsai_budget_emit_line(const fsai_budget_entry* entry, const char* stage_name,
+                                  uint64_t duration_ns) {
+    if (!g_budget_enabled || !entry || !entry->configured) {
+        return;
+    }
+
+    const double duration_ms = fsai_clock_to_seconds(duration_ns) * 1000.0;
+    const double budget_ms = fsai_clock_to_seconds(entry->budget_ns) * 1000.0;
+    const double usage_pct = (entry->budget_ns > 0)
+                                 ? (static_cast<double>(duration_ns) * 100.0) / entry->budget_ns
+                                 : 0.0;
+    const int over_budget = (entry->budget_ns > 0 && duration_ns > entry->budget_ns) ? 1 : 0;
+
+    if (stage_name && stage_name[0] != '\0') {
+        printf("[Timing][%s:%s] %.3f ms (budget %.3f ms, %.1f%%)%s\n",
+               entry->name ? entry->name : "<unnamed>", stage_name,
+               duration_ms, budget_ms, usage_pct,
+               over_budget ? " !! over budget" : "");
+    } else {
+        printf("[Timing][%s] %.3f ms (budget %.3f ms, %.1f%%)%s\n",
+               entry->name ? entry->name : "<unnamed>",
+               duration_ms, budget_ms, usage_pct,
+               over_budget ? " !! over budget" : "");
+    }
+}
+
+void fsai_budget_record(fsai_budget_subsystem subsystem, uint64_t duration_ns) {
+    if (!fsai_budget_valid_subsystem(subsystem)) {
+        return;
+    }
+    fsai_budget_entry* entry = &g_budget_entries[subsystem];
+    if (!entry->configured) {
+        return;
+    }
+
+    entry->last_duration_ns = duration_ns;
+    if (duration_ns > entry->worst_duration_ns) {
+        entry->worst_duration_ns = duration_ns;
+    }
+    entry->total_duration_ns += duration_ns;
+    entry->sample_count += 1;
+
+    fsai_budget_emit_line(entry, NULL, duration_ns);
+}
+
+void fsai_budget_stage_record(fsai_budget_subsystem subsystem, const char* stage_name,
+                              uint64_t duration_ns) {
+    if (!fsai_budget_valid_subsystem(subsystem)) {
+        return;
+    }
+    const fsai_budget_entry* entry = &g_budget_entries[subsystem];
+    if (!entry->configured) {
+        return;
+    }
+    fsai_budget_emit_line(entry, stage_name, duration_ns);
+}
+
+void fsai_budget_report_all(void) {
+    if (!g_budget_enabled) {
+        return;
+    }
+
+    printf("========== Timing Summary =========\n");
+    for (int i = 0; i < FSAI_BUDGET_SUBSYSTEM_COUNT; ++i) {
+        const fsai_budget_entry* entry = &g_budget_entries[i];
+        if (!entry->configured) {
+            continue;
+        }
+        printf("[%s] ", entry->name ? entry->name : "<unnamed>");
+        if (entry->sample_count == 0) {
+            if (entry->unimplemented_note) {
+                printf("no samples recorded (%s)\n", entry->unimplemented_note);
+            } else {
+                printf("no samples recorded\n");
+            }
+            continue;
+        }
+        const double avg_ms = fsai_clock_to_seconds(entry->total_duration_ns) * 1000.0 /
+                              (entry->sample_count > 0 ? entry->sample_count : 1);
+        const double worst_ms = fsai_clock_to_seconds(entry->worst_duration_ns) * 1000.0;
+        const double budget_ms = fsai_clock_to_seconds(entry->budget_ns) * 1000.0;
+        printf("avg %.3f ms, worst %.3f ms, budget %.3f ms\n", avg_ms, worst_ms, budget_ms);
+    }
+    printf("====================================\n");
+}
+

--- a/common/time/budget.h
+++ b/common/time/budget.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum fsai_budget_subsystem {
+    FSAI_BUDGET_SUBSYSTEM_SIMULATION = 0,
+    FSAI_BUDGET_SUBSYSTEM_VISION = 1,
+    FSAI_BUDGET_SUBSYSTEM_CONTROL = 2,
+    FSAI_BUDGET_SUBSYSTEM_CAN = 3,
+    FSAI_BUDGET_SUBSYSTEM_COUNT
+} fsai_budget_subsystem;
+
+void fsai_budget_init(void);
+void fsai_budget_set_enabled(int enabled);
+void fsai_budget_configure(fsai_budget_subsystem subsystem, const char* name, uint64_t budget_ns);
+void fsai_budget_mark_unimplemented(fsai_budget_subsystem subsystem, const char* note);
+void fsai_budget_record(fsai_budget_subsystem subsystem, uint64_t duration_ns);
+void fsai_budget_stage_record(fsai_budget_subsystem subsystem, const char* stage_name, uint64_t duration_ns);
+void fsai_budget_report_all(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+#include "fsai_clock.h"
+
+namespace fsai {
+namespace time {
+
+class ScopedBudgetTimer {
+public:
+    explicit ScopedBudgetTimer(fsai_budget_subsystem subsystem)
+        : subsystem_(subsystem), stage_name_(nullptr), start_ns_(fsai_clock_now()) {}
+
+    ScopedBudgetTimer(fsai_budget_subsystem subsystem, const char* stage_name)
+        : subsystem_(subsystem), stage_name_(stage_name), start_ns_(fsai_clock_now()) {}
+
+    ~ScopedBudgetTimer() {
+        const uint64_t duration_ns = fsai_clock_now() - start_ns_;
+        if (stage_name_) {
+            fsai_budget_stage_record(subsystem_, stage_name_, duration_ns);
+        } else {
+            fsai_budget_record(subsystem_, duration_ns);
+        }
+    }
+
+    ScopedBudgetTimer(const ScopedBudgetTimer&) = delete;
+    ScopedBudgetTimer& operator=(const ScopedBudgetTimer&) = delete;
+
+private:
+    fsai_budget_subsystem subsystem_;
+    const char* stage_name_;
+    uint64_t start_ns_;
+};
+
+class VisionStageTimer : public ScopedBudgetTimer {
+public:
+    explicit VisionStageTimer(const char* stage_name = nullptr)
+        : ScopedBudgetTimer(FSAI_BUDGET_SUBSYSTEM_VISION, stage_name) {}
+};
+
+class ControlStageTimer : public ScopedBudgetTimer {
+public:
+    explicit ControlStageTimer(const char* stage_name = nullptr)
+        : ScopedBudgetTimer(FSAI_BUDGET_SUBSYSTEM_CONTROL, stage_name) {}
+};
+
+class SimulationStageTimer : public ScopedBudgetTimer {
+public:
+    explicit SimulationStageTimer(const char* stage_name = nullptr)
+        : ScopedBudgetTimer(FSAI_BUDGET_SUBSYSTEM_SIMULATION, stage_name) {}
+};
+
+class CanStageTimer : public ScopedBudgetTimer {
+public:
+    explicit CanStageTimer(const char* stage_name = nullptr)
+        : ScopedBudgetTimer(FSAI_BUDGET_SUBSYSTEM_CAN, stage_name) {}
+};
+
+}  // namespace time
+}  // namespace fsai
+#endif
+

--- a/common/time/fsai_clock.cpp
+++ b/common/time/fsai_clock.cpp
@@ -1,0 +1,136 @@
+#include "fsai_clock.h"
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <mutex>
+
+namespace {
+struct ClockState {
+    std::atomic<bool> initialized{false};
+    fsai_clock_mode mode{FSAI_CLOCK_MODE_REALTIME};
+    uint64_t start_ns{0};
+    std::chrono::steady_clock::time_point realtime_origin{};
+    std::atomic<uint64_t> sim_now_ns{0};
+    std::atomic<uint64_t> last_tick_ns{0};
+    std::mutex mutex;
+};
+
+ClockState& clock_state() {
+    static ClockState state;
+    return state;
+}
+
+constexpr double kNsPerSec = 1e9;
+
+void ensure_initialized() {
+    ClockState& state = clock_state();
+    if (!state.initialized.load(std::memory_order_acquire)) {
+        std::lock_guard<std::mutex> lock(state.mutex);
+        if (!state.initialized.load(std::memory_order_relaxed)) {
+            state.mode = FSAI_CLOCK_MODE_REALTIME;
+            state.start_ns = 0;
+            state.realtime_origin = std::chrono::steady_clock::now();
+            state.sim_now_ns.store(0, std::memory_order_relaxed);
+            state.last_tick_ns.store(0, std::memory_order_relaxed);
+            state.initialized.store(true, std::memory_order_release);
+        }
+    }
+}
+
+uint64_t realtime_now_ns(const ClockState& state) {
+    const auto now = std::chrono::steady_clock::now();
+    const auto delta = std::chrono::duration_cast<std::chrono::nanoseconds>(now - state.realtime_origin);
+    return state.start_ns + static_cast<uint64_t>(delta.count());
+}
+
+}  // namespace
+
+void fsai_clock_init(fsai_clock_config config) {
+    ClockState& state = clock_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+
+    state.mode = config.mode;
+    state.start_ns = config.start_time_ns;
+    state.last_tick_ns.store(config.start_time_ns, std::memory_order_relaxed);
+
+    if (config.mode == FSAI_CLOCK_MODE_REALTIME) {
+        state.realtime_origin = std::chrono::steady_clock::now();
+        state.sim_now_ns.store(0, std::memory_order_relaxed);
+    } else {
+        state.sim_now_ns.store(config.start_time_ns, std::memory_order_relaxed);
+    }
+
+    state.initialized.store(true, std::memory_order_release);
+}
+
+void fsai_clock_shutdown(void) {
+    ClockState& state = clock_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    state.initialized.store(false, std::memory_order_release);
+}
+
+uint64_t fsai_clock_now(void) {
+    ensure_initialized();
+    ClockState& state = clock_state();
+    uint64_t value = 0;
+    if (state.mode == FSAI_CLOCK_MODE_REALTIME) {
+        value = realtime_now_ns(state);
+    } else {
+        value = state.sim_now_ns.load(std::memory_order_acquire);
+    }
+    state.last_tick_ns.store(value, std::memory_order_release);
+    return value;
+}
+
+uint64_t fsai_clock_last_tick(void) {
+    ensure_initialized();
+    ClockState& state = clock_state();
+    return state.last_tick_ns.load(std::memory_order_acquire);
+}
+
+uint64_t fsai_clock_advance(uint64_t delta_ns) {
+    ensure_initialized();
+    ClockState& state = clock_state();
+    if (state.mode == FSAI_CLOCK_MODE_REALTIME) {
+        // In realtime mode we cannot advance manually; return current time.
+        return fsai_clock_now();
+    }
+    uint64_t new_value = state.sim_now_ns.fetch_add(delta_ns, std::memory_order_acq_rel) + delta_ns;
+    state.last_tick_ns.store(new_value, std::memory_order_release);
+    return new_value;
+}
+
+uint64_t fsai_clock_set(uint64_t absolute_ns) {
+    ensure_initialized();
+    ClockState& state = clock_state();
+    if (state.mode == FSAI_CLOCK_MODE_REALTIME) {
+        std::lock_guard<std::mutex> lock(state.mutex);
+        state.start_ns = absolute_ns;
+        state.realtime_origin = std::chrono::steady_clock::now();
+        state.last_tick_ns.store(absolute_ns, std::memory_order_release);
+        return absolute_ns;
+    }
+    state.sim_now_ns.store(absolute_ns, std::memory_order_release);
+    state.last_tick_ns.store(absolute_ns, std::memory_order_release);
+    return absolute_ns;
+}
+
+uint64_t fsai_clock_from_seconds(double seconds) {
+    if (seconds <= 0.0) {
+        return 0ULL;
+    }
+    const double scaled = seconds * kNsPerSec;
+    return static_cast<uint64_t>(std::llround(scaled));
+}
+
+double fsai_clock_to_seconds(uint64_t nanoseconds) {
+    return static_cast<double>(nanoseconds) / kNsPerSec;
+}
+
+int fsai_clock_is_simulated(void) {
+    ensure_initialized();
+    ClockState& state = clock_state();
+    return state.mode == FSAI_CLOCK_MODE_SIMULATED ? 1 : 0;
+}
+

--- a/common/time/fsai_clock.h
+++ b/common/time/fsai_clock.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum fsai_clock_mode {
+    FSAI_CLOCK_MODE_REALTIME = 0,
+    FSAI_CLOCK_MODE_SIMULATED = 1
+} fsai_clock_mode;
+
+typedef struct fsai_clock_config {
+    fsai_clock_mode mode;
+    uint64_t start_time_ns;
+} fsai_clock_config;
+
+void fsai_clock_init(fsai_clock_config config);
+void fsai_clock_shutdown(void);
+uint64_t fsai_clock_now(void);
+uint64_t fsai_clock_last_tick(void);
+uint64_t fsai_clock_advance(uint64_t delta_ns);
+uint64_t fsai_clock_set(uint64_t absolute_ns);
+uint64_t fsai_clock_from_seconds(double seconds);
+double fsai_clock_to_seconds(uint64_t nanoseconds);
+int fsai_clock_is_simulated(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+namespace fsai {
+namespace time {
+inline uint64_t fromSeconds(double seconds) { return fsai_clock_from_seconds(seconds); }
+inline double toSeconds(uint64_t nanoseconds) { return fsai_clock_to_seconds(nanoseconds); }
+inline uint64_t now() { return fsai_clock_now(); }
+inline uint64_t advance(uint64_t delta_ns) { return fsai_clock_advance(delta_ns); }
+inline bool isSimulated() { return fsai_clock_is_simulated() != 0; }
+}
+}
+#endif
+

--- a/common/types.h
+++ b/common/types.h
@@ -1,0 +1,123 @@
+#pragma once
+
+// Canonical cross-team data contracts for FS-AI components. These structs are
+// shared across simulation, vision, and control modules and intentionally use C
+// linkage so they can be consumed from pure C, C++, or generated code.
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum FsaiPixelFormat {
+    FSAI_PIXEL_RGB888 = 0,
+    FSAI_PIXEL_NV12 = 1
+} FsaiPixelFormat;
+
+typedef struct FsaiCameraIntrinsics {
+    float fx, fy;
+    float cx, cy;
+    float k1, k2, p1, p2, k3;
+} FsaiCameraIntrinsics;
+
+typedef struct FsaiCameraExtrinsics {
+    float R[9];  // Row-major rotation body <- camera
+    float t[3];  // Translation body <- camera (meters)
+} FsaiCameraExtrinsics;
+
+typedef struct FsaiFrame {
+    uint64_t t_ns;     // Sensor timestamp (ns)
+    int w, h;          // Resolution
+    int stride;        // Bytes between rows
+    FsaiPixelFormat fmt;
+    FsaiCameraIntrinsics K;
+    FsaiCameraExtrinsics T_bw;  // Body <- camera extrinsics
+    uint8_t* data;               // Producer-owned buffer
+} FsaiFrame;
+
+typedef struct FsaiStereoFrame {
+    FsaiFrame left;
+    FsaiFrame right;
+    uint64_t t_sync_ns;  // Mid-exposure stereo timestamp
+} FsaiStereoFrame;
+
+typedef enum FsaiConeSide {
+    FSAI_CONE_LEFT = 0,
+    FSAI_CONE_RIGHT = 1,
+    FSAI_CONE_UNKNOWN = 2
+} FsaiConeSide;
+
+typedef struct FsaiConeDet {
+    float p_B[3];  // Body-frame (x,y,z) meters
+    FsaiConeSide side;
+    float conf;    // [0,1]
+    float cov[6];  // Optional covariance (xx,xy,xz,yy,yz,zz); zero if unused
+} FsaiConeDet;
+
+typedef struct FsaiDetections {
+    uint64_t t_ns;     // Sensor time of the associated stereo frame
+    int n;             // Number of detections (<=512)
+    FsaiConeDet dets[512];
+} FsaiDetections;
+
+typedef struct FsaiVehicleState {
+    uint64_t t_ns;
+    float x, y;
+    float yaw;
+    float vx, vy;
+    float yaw_rate;
+    float ax, ay;
+    float steer_rad;
+} FsaiVehicleState;
+
+typedef struct FsaiControlCmd {
+    float steer_rad;
+    float throttle;
+    float brake;
+    uint64_t t_ns;
+} FsaiControlCmd;
+
+typedef struct FsaiCanMsg {
+    uint32_t id;
+    uint8_t dlc;
+    uint8_t data[8];
+    uint64_t t_ns;
+} FsaiCanMsg;
+
+#ifndef __cplusplus
+typedef FsaiPixelFormat PixelFormat;
+typedef FsaiCameraIntrinsics CameraIntrinsics;
+typedef FsaiCameraExtrinsics CameraExtrinsics;
+typedef FsaiFrame Frame;
+typedef FsaiStereoFrame StereoFrame;
+typedef FsaiConeSide ConeSide;
+typedef FsaiConeDet ConeDet;
+typedef FsaiDetections Detections;
+typedef FsaiVehicleState VehicleState;
+typedef FsaiControlCmd ControlCmd;
+typedef FsaiCanMsg CanMsg;
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+namespace fsai {
+namespace types {
+using PixelFormat = ::FsaiPixelFormat;
+using CameraIntrinsics = ::FsaiCameraIntrinsics;
+using CameraExtrinsics = ::FsaiCameraExtrinsics;
+using Frame = ::FsaiFrame;
+using StereoFrame = ::FsaiStereoFrame;
+using ConeSide = ::FsaiConeSide;
+using ConeDet = ::FsaiConeDet;
+using Detections = ::FsaiDetections;
+using VehicleState = ::FsaiVehicleState;
+using ControlCmd = ::FsaiControlCmd;
+using CanMsg = ::FsaiCanMsg;
+}  // namespace types
+}  // namespace fsai
+#endif
+

--- a/sim/World.cpp
+++ b/sim/World.cpp
@@ -1,6 +1,7 @@
 #include "World.hpp"
 #include <cstdio>
 #include <cmath>
+#include "fsai_clock.h"
 
 static Vector3 transformToVector3(const Transform& t) {
     return {t.position.x, t.position.y, t.position.z};
@@ -169,7 +170,8 @@ bool World::detectCollisions() {
 }
 
 void World::telemetry() const {
-    Telemetry_Update(carState, carTransform, totalTime, totalDistance, lapCount);
+    Telemetry_Update(carState, carTransform,
+                     fsai_clock_now(), totalTime, totalDistance, lapCount);
 }
 
 void World::moveNextCheckpointToLast() {


### PR DESCRIPTION
## Summary
- add a reusable monotonic clock module that supports simulated and real-time operation
- propagate nanosecond timestamps through the main controller, car controller, telemetry, and vehicle state
- update build configuration to compile the new clock utilities and wire telemetry to the shared clock

## Testing
- cmake -S . -B build *(fails: missing Eigen3 dependency in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7a4e22b9c832484279d6d69ed7ee7