### PR TITLE
Align simulated VCU CAN traffic with ADS-DV DBC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,9 @@ file(GLOB_RECURSE SIM_APP_SOURCES CONFIGURE_DEPENDS
 add_executable(fsai_run ${SIM_APP_SOURCES})
 target_link_libraries(fsai_run PRIVATE fsai_sim fsai_rendering)
 
+add_executable(svcu_run sim/svcu/svcu_main.cpp)
+target_link_libraries(svcu_run PRIVATE fsai_sim)
+
 # ------------------------------------------------------------------------------
 # Tests
 # ------------------------------------------------------------------------------

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -1,9 +1,14 @@
+#include <algorithm>
 #include <array>
+#include <chrono>
+#include <numbers>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include <SDL.h>
@@ -18,6 +23,9 @@
 #include "sim_stereo_source.hpp"
 #include "types.h"
 #include "World.hpp"
+#include "adsdv_dbc.hpp"
+#include "link.hpp"
+#include "socketcan.hpp"
 
 namespace {
 constexpr double kDefaultDt = 0.01;
@@ -25,21 +33,73 @@ constexpr int kWindowWidth = 800;
 constexpr int kWindowHeight = 600;
 constexpr int kReportIntervalFrames = 120;
 constexpr float kRenderScale = 5.0f;
+constexpr const char* kDefaultCanIface = "vcan0";
+constexpr uint16_t kDefaultCommandPort = fsai::sim::svcu::kDefaultCommandPort;
+constexpr uint16_t kDefaultTelemetryPort = fsai::sim::svcu::kDefaultTelemetryPort;
+constexpr double kCommandStaleSeconds = 0.1;
+constexpr double kBaseLatitudeDeg = 37.4275;
+constexpr double kBaseLongitudeDeg = -122.1697;
+constexpr double kMetersPerDegreeLat = 111111.0;
+
+inline double metersToLatitude(double north_meters) {
+  return kBaseLatitudeDeg + north_meters / kMetersPerDegreeLat;
+}
+
+inline double metersToLongitude(double east_meters) {
+  const double cos_lat = std::cos(kBaseLatitudeDeg * std::numbers::pi / 180.0);
+  const double meters_per_degree_lon =
+      kMetersPerDegreeLat * std::max(0.1, cos_lat);
+  return kBaseLongitudeDeg + east_meters / meters_per_degree_lon;
+}
 }  // namespace
 
 int main(int argc, char* argv[]) {
   std::srand(static_cast<unsigned>(std::time(nullptr)));
 
+  auto parse_port = [](const char* text, uint16_t fallback) {
+    if (!text) return fallback;
+    char* end = nullptr;
+    long value = std::strtol(text, &end, 10);
+    if (end == text || value < 0 || value > 65535) {
+      return fallback;
+    }
+    return static_cast<uint16_t>(value);
+  };
+
   double dt = kDefaultDt;
-  if (argc > 1) {
-    dt = std::atof(argv[1]);
-    if (dt <= 0.0) {
-      std::printf("Invalid dt value provided. Using default dt = %.3f\n",
-                  kDefaultDt);
-      dt = kDefaultDt;
+  std::string can_iface = kDefaultCanIface;
+  uint16_t command_port = kDefaultCommandPort;
+  uint16_t telemetry_port = kDefaultTelemetryPort;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--dt" && i + 1 < argc) {
+      dt = std::atof(argv[++i]);
+    } else if (arg == "--can-if" && i + 1 < argc) {
+      can_iface = argv[++i];
+    } else if (arg == "--cmd-port" && i + 1 < argc) {
+      command_port = parse_port(argv[++i], command_port);
+    } else if (arg == "--state-port" && i + 1 < argc) {
+      telemetry_port = parse_port(argv[++i], telemetry_port);
+    } else if (arg == "--help") {
+      std::printf(
+          "Usage: fsai_run [--dt seconds] [--can-if iface] [--cmd-port p] "
+          "[--state-port p]\n");
+      return EXIT_SUCCESS;
+    } else if (i == 1 && argc == 2) {
+      dt = std::atof(arg.c_str());
+    } else {
+      std::printf("Ignoring unrecognized argument '%s'\n", arg.c_str());
     }
   }
-  std::printf("Using dt = %.4f seconds\n", dt);
+
+  if (dt <= 0.0) {
+    std::printf("Invalid dt value provided. Using default dt = %.3f\n",
+                kDefaultDt);
+    dt = kDefaultDt;
+  }
+  std::printf("Using dt = %.4f seconds, CAN %s, cmd-port %u, state-port %u\n",
+              dt, can_iface.c_str(), command_port, telemetry_port);
 
   fsai_clock_config clock_cfg{};
   clock_cfg.mode = FSAI_CLOCK_MODE_SIMULATED;
@@ -96,6 +156,55 @@ int main(int argc, char* argv[]) {
   bool running = true;
   size_t frame_counter = 0;
 
+  fsai::sim::svcu::SocketCan can_bus;
+  if (!can_bus.open(can_iface, true)) {
+    std::fprintf(stderr, "Failed to open CAN interface %s\n", can_iface.c_str());
+    return EXIT_FAILURE;
+  }
+
+  fsai::sim::svcu::UdpEndpoint command_rx;
+  if (!command_rx.bind(command_port)) {
+    std::fprintf(stderr, "Failed to bind command UDP port %u\n", command_port);
+    return EXIT_FAILURE;
+  }
+
+  fsai::sim::svcu::UdpEndpoint telemetry_tx;
+  if (!telemetry_tx.connect(telemetry_port)) {
+    std::fprintf(stderr, "Failed to connect telemetry UDP port %u\n",
+                 telemetry_port);
+    return EXIT_FAILURE;
+  }
+
+  const VehicleParam& vehicle_param = world.model().param();
+  const int front_motor_count = std::max(0, vehicle_param.powertrain.front_motor_count);
+  const int rear_motor_count = std::max(0, vehicle_param.powertrain.rear_motor_count);
+  const int total_motors = std::max(1, front_motor_count + rear_motor_count);
+  float tmp_front_motor_weight =
+      total_motors > 0 ? static_cast<float>(front_motor_count) / total_motors
+                       : 0.5f;
+  tmp_front_motor_weight = std::clamp(tmp_front_motor_weight, 0.0f, 1.0f);
+  if (tmp_front_motor_weight <= 0.0f &&
+      std::clamp(1.0f - tmp_front_motor_weight, 0.0f, 1.0f) <= 0.0f) {
+    tmp_front_motor_weight = 0.5f;
+  }
+  const float front_motor_weight = tmp_front_motor_weight;
+  const float rear_motor_weight = std::clamp(1.0f - front_motor_weight, 0.0f, 1.0f);
+
+  float tmp_brake_front_bias = static_cast<float>(vehicle_param.brakes.front_bias);
+  float tmp_brake_rear_bias = static_cast<float>(vehicle_param.brakes.rear_bias);
+  const float brake_sum = tmp_brake_front_bias + tmp_brake_rear_bias;
+  if (brake_sum > 0.0f) {
+    tmp_brake_front_bias = std::clamp(tmp_brake_front_bias / brake_sum, 0.0f, 1.0f);
+  } else {
+    tmp_brake_front_bias = 0.5f;
+  }
+  const float brake_front_bias = tmp_brake_front_bias;
+  const float brake_rear_bias = std::clamp(1.0f - brake_front_bias, 0.0f, 1.0f);
+
+  std::optional<fsai::sim::svcu::CommandPacket> latest_command;
+  const uint64_t stale_threshold_ns =
+      fsai_clock_from_seconds(kCommandStaleSeconds);
+
   while (running) {
     SDL_Event event;
     while (SDL_PollEvent(&event)) {
@@ -117,8 +226,10 @@ int main(int argc, char* argv[]) {
     } else if (!world.useRacingAlgorithm && key != -1) {
       if (key == 'w' || key == 'W') {
         world.throttleInput = 1.0f;
+        world.brakeInput = 0.0f;
       } else if (key == 's' || key == 'S') {
-        world.throttleInput = -1.0f;
+        world.throttleInput = 0.0f;
+        world.brakeInput = 1.0f;
       }
       if (key == 'a' || key == 'A') {
         world.steeringAngle = -1.0f;
@@ -127,12 +238,155 @@ int main(int argc, char* argv[]) {
       }
     }
 
+    float autopThrottle = world.throttleInput;
+    float autopBrake = world.brakeInput;
+    float autopSteer = world.steeringAngle;
+    if (world.useRacingAlgorithm) {
+      float raThrottle = 0.0f;
+      float raSteer = 0.0f;
+      if (world.computeRacingControl(step_seconds, raThrottle, raSteer)) {
+        autopSteer = raSteer;
+        if (raThrottle >= 0.0f) {
+          autopThrottle = raThrottle;
+          autopBrake = 0.0f;
+        } else {
+          autopThrottle = 0.0f;
+          autopBrake = -raThrottle;
+        }
+      }
+    }
+
+    const float throttle_cmd = std::clamp(autopThrottle, 0.0f, 1.0f);
+    const float brake_cmd = std::clamp(autopBrake, 0.0f, 1.0f);
+
+    const VehicleState& veh_state = world.vehicleState();
+    const double vx = veh_state.velocity.x();
+    const double vy = veh_state.velocity.y();
+    const float speed_mps = static_cast<float>(std::sqrt(vx * vx + vy * vy));
+    const float speed_kph = speed_mps * 3.6f;
+    const float target_speed_kph = std::clamp(
+        static_cast<float>(vehicle_param.input_ranges.vel.max * throttle_cmd * 3.6),
+        0.0f, 255.0f);
+
+    fsai::sim::svcu::dbc::Ai2VcuStatus status_msg{};
+    status_msg.handshake = true;
+    status_msg.estop_request = false;
+    status_msg.mission_status = world.useRacingAlgorithm
+                                    ? fsai::sim::svcu::dbc::MissionStatus::kRunning
+                                    : fsai::sim::svcu::dbc::MissionStatus::kSelected;
+    status_msg.direction_request = fsai::sim::svcu::dbc::DirectionRequest::kForward;
+    status_msg.lap_counter = static_cast<uint8_t>(
+        std::clamp(world.completedLaps(), 0, 15));
+    status_msg.cones_count_actual = 0;
+    status_msg.cones_count_all = 0;
+    status_msg.veh_speed_actual_kph = speed_kph;
+    status_msg.veh_speed_demand_kph = target_speed_kph;
+    can_bus.send(fsai::sim::svcu::dbc::encode_ai2vcu_status(status_msg));
+
+    const float total_torque_nm = throttle_cmd *
+                                  2.0f * fsai::sim::svcu::dbc::kMaxAxleTorqueNm;
+    float front_torque_request_nm =
+        std::clamp(total_torque_nm * front_motor_weight, 0.0f,
+                   fsai::sim::svcu::dbc::kMaxAxleTorqueNm);
+    float rear_torque_request_nm =
+        std::clamp(total_torque_nm * rear_motor_weight, 0.0f,
+                   fsai::sim::svcu::dbc::kMaxAxleTorqueNm);
+
+    fsai::sim::svcu::dbc::Ai2VcuSteer steer_msg{};
+    steer_msg.steer_deg = std::clamp(autopSteer * fsai::sim::svcu::dbc::kRadToDeg,
+                                     -fsai::sim::svcu::dbc::kMaxSteerDeg,
+                                     fsai::sim::svcu::dbc::kMaxSteerDeg);
+    can_bus.send(fsai::sim::svcu::dbc::encode_ai2vcu_steer(steer_msg));
+
+    fsai::sim::svcu::dbc::Ai2VcuDrive front_drive{};
+    front_drive.axle_torque_request_nm = front_torque_request_nm;
+    front_drive.motor_speed_max_rpm = 4000.0f;
+    can_bus.send(fsai::sim::svcu::dbc::encode_ai2vcu_drive_front(front_drive));
+
+    fsai::sim::svcu::dbc::Ai2VcuDrive rear_drive{};
+    rear_drive.axle_torque_request_nm = rear_torque_request_nm;
+    rear_drive.motor_speed_max_rpm = 4000.0f;
+    can_bus.send(fsai::sim::svcu::dbc::encode_ai2vcu_drive_rear(rear_drive));
+
+    fsai::sim::svcu::dbc::Ai2VcuBrake brake_msg{};
+    const float brake_pct_total = brake_cmd * 100.0f;
+    brake_msg.front_pct = std::clamp(brake_pct_total * brake_front_bias, 0.0f,
+                                     fsai::sim::svcu::dbc::kMaxBrakePercent);
+    brake_msg.rear_pct = std::clamp(brake_pct_total * brake_rear_bias, 0.0f,
+                                    fsai::sim::svcu::dbc::kMaxBrakePercent);
+    can_bus.send(fsai::sim::svcu::dbc::encode_ai2vcu_brake(brake_msg));
+
+    fsai::sim::svcu::CommandPacket command_packet{};
+    while (auto bytes = command_rx.receive(&command_packet, sizeof(command_packet))) {
+      if (*bytes == sizeof(command_packet)) {
+        latest_command = command_packet;
+      }
+    }
+
     const uint64_t now_ns = fsai_clock_advance(step_ns);
+
+    float appliedThrottle = autopThrottle;
+    float appliedBrake = autopBrake;
+    float appliedSteer = autopSteer;
+    if (latest_command) {
+      if (latest_command->t_ns <= now_ns &&
+          now_ns - latest_command->t_ns <= stale_threshold_ns) {
+        appliedThrottle = latest_command->throttle;
+        appliedBrake = latest_command->brake;
+        appliedSteer = latest_command->steer_rad;
+      }
+    }
+
+    appliedThrottle = std::clamp(appliedThrottle, 0.0f, 1.0f);
+    appliedBrake = std::clamp(appliedBrake, 0.0f, 1.0f);
+
+    world.setSvcuCommand(appliedThrottle, appliedBrake, appliedSteer);
+    world.throttleInput = appliedThrottle;
+    world.brakeInput = appliedBrake;
+    world.steeringAngle = appliedSteer;
+
     {
       fsai::time::ControlStageTimer control_timer("world_update");
       world.update(step_seconds);
     }
     const double sim_time_s = fsai_clock_to_seconds(now_ns);
+
+    const auto& vehicle_state = world.vehicleState();
+    const auto& model = world.model();
+    const auto& pt_status = model.lastPowertrainStatus();
+    const auto& brake_status = model.lastBrakeStatus();
+    const WheelsInfo& wheel_info = world.wheelsInfo();
+    const double wheel_radius = std::max(0.01, model.param().tire.radius);
+    const double front_force = pt_status.front_drive_force - pt_status.front_regen_force -
+                               brake_status.front_force;
+    const double rear_force = pt_status.rear_drive_force - pt_status.rear_regen_force -
+                              brake_status.rear_force;
+
+    fsai::sim::svcu::TelemetryPacket telemetry{};
+    telemetry.t_ns = now_ns;
+    telemetry.steer_angle_rad = appliedSteer;
+    telemetry.front_axle_torque_nm = static_cast<float>(front_force * wheel_radius);
+    telemetry.rear_axle_torque_nm = static_cast<float>(rear_force * wheel_radius);
+    telemetry.wheel_speed_rpm[0] = wheel_info.lf_speed;
+    telemetry.wheel_speed_rpm[1] = wheel_info.rf_speed;
+    telemetry.wheel_speed_rpm[2] = wheel_info.lb_speed;
+    telemetry.wheel_speed_rpm[3] = wheel_info.rb_speed;
+    telemetry.brake_pressure_front_bar =
+        static_cast<float>(std::max(0.0, brake_status.front_force) / 1000.0);
+    telemetry.brake_pressure_rear_bar =
+        static_cast<float>(std::max(0.0, brake_status.rear_force) / 1000.0);
+    telemetry.imu_ax_mps2 = static_cast<float>(vehicle_state.acceleration.x());
+    telemetry.imu_ay_mps2 = static_cast<float>(vehicle_state.acceleration.y());
+    telemetry.imu_yaw_rate_rps = static_cast<float>(vehicle_state.rotation.z());
+    telemetry.gps_lat_deg = static_cast<float>(
+        metersToLatitude(vehicle_state.position.y()));
+    telemetry.gps_lon_deg = static_cast<float>(
+        metersToLongitude(vehicle_state.position.x()));
+    telemetry.gps_speed_mps = static_cast<float>(
+        std::sqrt(vehicle_state.velocity.x() * vehicle_state.velocity.x() +
+                  vehicle_state.velocity.y() * vehicle_state.velocity.y()));
+    telemetry.status_flags = static_cast<uint8_t>(world.useRacingAlgorithm ? 0x3 : 0x1);
+    telemetry_tx.send(&telemetry, sizeof(telemetry));
 
     logger.logState(sim_time_s, world.vehicleState());
     logger.logControl(sim_time_s, world.throttleInput, world.steeringAngle);

--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -32,6 +32,7 @@ public:
     // Public control parameters for manual control or algorithms.
     float steeringAngle{0.0f};
     float throttleInput{0.0f};
+    float brakeInput{0.0f};
     int useRacingAlgorithm{1};
     int regenTrack{1};
 
@@ -43,10 +44,16 @@ public:
     const std::vector<Vector3>& leftConePositions() const { return leftCones; }
     const std::vector<Vector3>& rightConePositions() const { return rightCones; }
     const LookaheadIndices& lookahead() const { return lookaheadIndices; }
+    const WheelsInfo& wheelsInfo() const { return wheelsInfo_; }
     double lapTimeSeconds() const { return totalTime; }
     double totalDistanceMeters() const { return totalDistance; }
     double timeStepSeconds() const { return deltaTime; }
     int completedLaps() const { return lapCount; }
+
+    bool computeRacingControl(double dt, float& throttle_out, float& steering_out);
+    void setSvcuCommand(float throttle, float brake, float steer);
+    bool hasSvcuCommand() const { return hasSvcuCommand_; }
+    const DynamicBicycle& model() const { return carModel; }
 
 private:
     void moveNextCheckpointToLast();
@@ -63,6 +70,12 @@ private:
     std::vector<Vector3> leftCones{};
     std::vector<Vector3> rightCones{};
     Vector3 lastCheckpoint{0.0f, 0.0f, 0.0f};
+
+    WheelsInfo wheelsInfo_{WheelsInfo_default()};
+    bool hasSvcuCommand_{false};
+    float lastSvcuThrottle_{0.0f};
+    float lastSvcuBrake_{0.0f};
+    float lastSvcuSteer_{0.0f};
 
     struct Config {
         float collisionThreshold{2.5f};

--- a/sim/include/sim/vehicle/DynamicBicycle.hpp
+++ b/sim/include/sim/vehicle/DynamicBicycle.hpp
@@ -27,21 +27,26 @@ public:
 class DynamicBicycle : public VehicleModel {
 public:
     using VehicleModel::VehicleModel;
-    struct Forces { double Fx; double FyF; double FyR; };
+  struct Forces { double Fx; double FyF; double FyR; };
 
-    void updateState(VehicleState& state, const VehicleInput& input, double dt) override;
-    static double calculateMagnitude(double x, double y);
+  void updateState(VehicleState& state, const VehicleInput& input, double dt) override;
+  static double calculateMagnitude(double x, double y);
+
+  const PowertrainStatus& lastPowertrainStatus() const { return last_pt_status_; }
+  const BrakeStatus& lastBrakeStatus() const { return last_brake_status_; }
 
 private:
-    // Actuator states (first-order lags)
-    mutable double thr_eff_{0.0};
-    mutable double brk_eff_{0.0};
+  // Actuator states (first-order lags)
+  mutable double thr_eff_{0.0};
+  mutable double brk_eff_{0.0};
 
-    // Runtime powertrain/brakes
-    mutable EVMotorPowertrain pt_;
-    mutable BrakeController   br_;
+  // Runtime powertrain/brakes
+  mutable EVMotorPowertrain pt_;
+  mutable BrakeController   br_;
+  mutable PowertrainStatus  last_pt_status_{};
+  mutable BrakeStatus       last_brake_status_{};
 
-    Forces computeForces(const VehicleState& state, const VehicleInput& input, double dt) const;
+  Forces computeForces(const VehicleState& state, const VehicleInput& input, double dt) const;
 
     // helpers
     static inline double clamp(double v, double lo, double hi){ return v<lo?lo:(v>hi?hi:v); }

--- a/sim/src/vehicle/DynamicBicycle.cpp
+++ b/sim/src/vehicle/DynamicBicycle.cpp
@@ -145,6 +145,8 @@ DynamicBicycle::Forces DynamicBicycle::computeForces(const VehicleState& x, cons
     const BrakeRequest breq = br_.prepare(static_cast<float>(brk_eff_), static_cast<float>(vx));
     const PowertrainStatus ps = pt_.compute(static_cast<float>(thr_eff_), breq.regen_command, static_cast<float>(vx), static_cast<float>(dt));
     const BrakeStatus     bst = br_.finalize(breq, ps.regen_force);
+    last_pt_status_ = ps;
+    last_brake_status_ = bst;
 
     // Raw Fx components (before ellipse), sign convention: forward positive
     double Fx_drive = double(ps.wheel_force);

--- a/sim/svcu/adsdv_dbc.cpp
+++ b/sim/svcu/adsdv_dbc.cpp
@@ -1,0 +1,323 @@
+#include "adsdv_dbc.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
+namespace fsai::sim::svcu::dbc {
+namespace {
+
+template <typename T>
+constexpr T clamp(T value, T min, T max) {
+  return value < min ? min : (value > max ? max : value);
+}
+
+inline void write_u16_le(uint8_t* dst, uint16_t value) {
+  dst[0] = static_cast<uint8_t>(value & 0xFFu);
+  dst[1] = static_cast<uint8_t>((value >> 8) & 0xFFu);
+}
+
+inline uint16_t read_u16_le(const uint8_t* src) {
+  return static_cast<uint16_t>(src[0] | (static_cast<uint16_t>(src[1]) << 8));
+}
+
+inline int16_t read_i16_le(const uint8_t* src) {
+  return static_cast<int16_t>(src[0] | (static_cast<uint16_t>(src[1]) << 8));
+}
+
+inline uint32_t read_bits_le(const uint8_t* data, int start_bit, int length) {
+  uint32_t value = 0;
+  for (int i = 0; i < length; ++i) {
+    const int bit_index = start_bit + i;
+    const int byte_index = bit_index / 8;
+    const int bit_in_byte = bit_index % 8;
+    const uint8_t bit = (data[byte_index] >> bit_in_byte) & 0x1u;
+    value |= static_cast<uint32_t>(bit) << i;
+  }
+  return value;
+}
+
+inline void write_bits_le(uint8_t* data, int start_bit, int length, uint32_t value) {
+  for (int i = 0; i < length; ++i) {
+    const int bit_index = start_bit + i;
+    const int byte_index = bit_index / 8;
+    const int bit_in_byte = bit_index % 8;
+    const uint8_t mask = static_cast<uint8_t>(1u << bit_in_byte);
+    if ((value >> i) & 0x1u) {
+      data[byte_index] |= mask;
+    } else {
+      data[byte_index] &= static_cast<uint8_t>(~mask);
+    }
+  }
+}
+
+inline int16_t pack_i16(double value, double scale, double min, double max) {
+  const double limited = clamp(value, min, max);
+  const double raw = std::round(limited / scale);
+  return static_cast<int16_t>(clamp(raw, -32768.0, 32767.0));
+}
+
+inline uint16_t pack_u16(double value, double scale, double min, double max) {
+  const double limited = clamp(value, min, max);
+  const double raw = std::round(limited / scale);
+  return static_cast<uint16_t>(clamp(raw, 0.0, 65535.0));
+}
+
+inline uint8_t pack_u8(double value, double scale, double min, double max) {
+  const double limited = clamp(value, min, max);
+  const double raw = std::round(limited / scale);
+  return static_cast<uint8_t>(clamp(raw, 0.0, 255.0));
+}
+
+inline int8_t pack_i8(double value, double scale, double min, double max) {
+  const double limited = clamp(value, min, max);
+  const double raw = std::round(limited / scale);
+  return static_cast<int8_t>(clamp(raw, -128.0, 127.0));
+}
+
+}  // namespace
+
+bool decode_ai2vcu_status(const can_frame& frame, Ai2VcuStatus& out) {
+  if (frame.can_id != kMsgIdAi2VcuStatus || frame.can_dlc < 8) {
+    return false;
+  }
+
+  std::memset(&out, 0, sizeof(out));
+  out.handshake = read_bits_le(frame.data, 0, 1) != 0;
+  out.estop_request = read_bits_le(frame.data, 8, 1) != 0;
+  out.mission_status = static_cast<MissionStatus>(read_bits_le(frame.data, 12, 2));
+  out.direction_request = static_cast<DirectionRequest>(read_bits_le(frame.data, 14, 2));
+  out.lap_counter = static_cast<uint8_t>(read_bits_le(frame.data, 16, 4));
+  out.cones_count_actual = static_cast<uint8_t>(read_bits_le(frame.data, 24, 8));
+  out.cones_count_all = static_cast<uint16_t>(read_bits_le(frame.data, 32, 16));
+  out.veh_speed_actual_kph = static_cast<float>(read_bits_le(frame.data, 48, 8));
+  out.veh_speed_demand_kph = static_cast<float>(read_bits_le(frame.data, 56, 8));
+  return true;
+}
+
+bool decode_ai2vcu_drive_front(const can_frame& frame, Ai2VcuDrive& out) {
+  if (frame.can_id != kMsgIdAi2VcuDriveFront || frame.can_dlc < 4) {
+    return false;
+  }
+  out.axle_torque_request_nm = static_cast<float>(read_u16_le(frame.data) * 0.1f);
+  out.motor_speed_max_rpm = static_cast<float>(read_u16_le(frame.data + 2) * 1.0f);
+  return true;
+}
+
+bool decode_ai2vcu_drive_rear(const can_frame& frame, Ai2VcuDrive& out) {
+  if (frame.can_id != kMsgIdAi2VcuDriveRear || frame.can_dlc < 4) {
+    return false;
+  }
+  out.axle_torque_request_nm = static_cast<float>(read_u16_le(frame.data) * 0.1f);
+  out.motor_speed_max_rpm = static_cast<float>(read_u16_le(frame.data + 2) * 1.0f);
+  return true;
+}
+
+bool decode_ai2vcu_steer(const can_frame& frame, Ai2VcuSteer& out) {
+  if (frame.can_id != kMsgIdAi2VcuSteer || frame.can_dlc < 2) {
+    return false;
+  }
+  out.steer_deg = static_cast<float>(read_i16_le(frame.data) * 0.1f);
+  return true;
+}
+
+bool decode_ai2vcu_brake(const can_frame& frame, Ai2VcuBrake& out) {
+  if (frame.can_id != kMsgIdAi2VcuBrake || frame.can_dlc < 2) {
+    return false;
+  }
+  out.front_pct = static_cast<float>(frame.data[0]) * 0.5f;
+  out.rear_pct = static_cast<float>(frame.data[1]) * 0.5f;
+  return true;
+}
+
+can_frame encode_ai2vcu_status(const Ai2VcuStatus& status) {
+  can_frame frame{};
+  frame.can_id = kMsgIdAi2VcuStatus;
+  frame.can_dlc = 8;
+  std::memset(frame.data, 0, sizeof(frame.data));
+
+  write_bits_le(frame.data, 0, 1, status.handshake ? 1u : 0u);
+  write_bits_le(frame.data, 8, 1, status.estop_request ? 1u : 0u);
+  write_bits_le(frame.data, 12, 2, static_cast<uint32_t>(status.mission_status));
+  write_bits_le(frame.data, 14, 2, static_cast<uint32_t>(status.direction_request));
+  write_bits_le(frame.data, 16, 4, status.lap_counter);
+  write_bits_le(frame.data, 24, 8, status.cones_count_actual);
+  write_bits_le(frame.data, 32, 16, status.cones_count_all);
+  write_bits_le(frame.data, 48, 8, pack_u8(status.veh_speed_actual_kph, 1.0, 0.0, 255.0));
+  write_bits_le(frame.data, 56, 8, pack_u8(status.veh_speed_demand_kph, 1.0, 0.0, 255.0));
+  return frame;
+}
+
+can_frame encode_ai2vcu_drive_front(const Ai2VcuDrive& drive) {
+  can_frame frame{};
+  frame.can_id = kMsgIdAi2VcuDriveFront;
+  frame.can_dlc = 4;
+  write_u16_le(frame.data, pack_u16(drive.axle_torque_request_nm, 0.1, 0.0, kMaxAxleTorqueNm));
+  write_u16_le(frame.data + 2, pack_u16(drive.motor_speed_max_rpm, 1.0, 0.0, 4000.0));
+  return frame;
+}
+
+can_frame encode_ai2vcu_drive_rear(const Ai2VcuDrive& drive) {
+  can_frame frame{};
+  frame.can_id = kMsgIdAi2VcuDriveRear;
+  frame.can_dlc = 4;
+  write_u16_le(frame.data, pack_u16(drive.axle_torque_request_nm, 0.1, 0.0, kMaxAxleTorqueNm));
+  write_u16_le(frame.data + 2, pack_u16(drive.motor_speed_max_rpm, 1.0, 0.0, 4000.0));
+  return frame;
+}
+
+can_frame encode_ai2vcu_steer(const Ai2VcuSteer& steer) {
+  can_frame frame{};
+  frame.can_id = kMsgIdAi2VcuSteer;
+  frame.can_dlc = 2;
+  const int16_t raw = pack_i16(steer.steer_deg, 0.1, -kMaxSteerDeg, kMaxSteerDeg);
+  write_u16_le(frame.data, static_cast<uint16_t>(raw));
+  return frame;
+}
+
+can_frame encode_ai2vcu_brake(const Ai2VcuBrake& brake) {
+  can_frame frame{};
+  frame.can_id = kMsgIdAi2VcuBrake;
+  frame.can_dlc = 2;
+  frame.data[0] = pack_u8(brake.front_pct, 0.5, 0.0, kMaxBrakePercent);
+  frame.data[1] = pack_u8(brake.rear_pct, 0.5, 0.0, kMaxBrakePercent);
+  return frame;
+}
+
+can_frame encode_vcu2ai_status(const Vcu2AiStatus& status) {
+  can_frame frame{};
+  frame.can_id = kMsgIdVcu2AiStatus;
+  frame.can_dlc = 8;
+  std::memset(frame.data, 0, sizeof(frame.data));
+
+  write_bits_le(frame.data, 0, 1, status.handshake ? 1u : 0u);
+  write_bits_le(frame.data, 8, 1, status.shutdown_request ? 1u : 0u);
+  write_bits_le(frame.data, 9, 1, status.as_switch_on ? 1u : 0u);
+  write_bits_le(frame.data, 10, 1, status.ts_switch_on ? 1u : 0u);
+  write_bits_le(frame.data, 11, 1, status.go_signal ? 1u : 0u);
+  write_bits_le(frame.data, 12, 2, static_cast<uint32_t>(status.steering_status));
+  write_bits_le(frame.data, 16, 4, static_cast<uint32_t>(status.as_state));
+  write_bits_le(frame.data, 20, 4, clamp<uint32_t>(status.ami_state, 0u, 15u));
+  write_bits_le(frame.data, 24, 1, status.fault ? 1u : 0u);
+  write_bits_le(frame.data, 25, 1, status.warning ? 1u : 0u);
+  write_bits_le(frame.data, 40, 1, status.ai_estop_request ? 1u : 0u);
+  write_bits_le(frame.data, 41, 1, status.hvil_open_fault ? 1u : 0u);
+  write_bits_le(frame.data, 42, 1, status.hvil_short_fault ? 1u : 0u);
+  write_bits_le(frame.data, 43, 1, status.ebs_fault ? 1u : 0u);
+  write_bits_le(frame.data, 44, 1, status.offboard_charger_fault ? 1u : 0u);
+  write_bits_le(frame.data, 45, 1, status.ai_comms_lost ? 1u : 0u);
+  write_bits_le(frame.data, 32, 1, status.warn_batt_temp_high ? 1u : 0u);
+  write_bits_le(frame.data, 33, 1, status.warn_batt_soc_low ? 1u : 0u);
+  write_bits_le(frame.data, 48, 1, status.charge_procedure_fault ? 1u : 0u);
+  write_bits_le(frame.data, 46, 1, status.autonomous_braking_fault ? 1u : 0u);
+  write_bits_le(frame.data, 47, 1, status.mission_status_fault ? 1u : 0u);
+  write_bits_le(frame.data, 56, 8, status.shutdown_cause);
+  write_bits_le(frame.data, 49, 1, status.bms_fault ? 1u : 0u);
+  write_bits_le(frame.data, 50, 1, status.brake_plausibility_fault ? 1u : 0u);
+  return frame;
+}
+
+can_frame encode_vcu2ai_steer(const Vcu2AiSteer& steer) {
+  can_frame frame{};
+  frame.can_id = kMsgIdVcu2AiSteer;
+  frame.can_dlc = 6;
+  const int16_t angle_raw = pack_i16(steer.angle_deg, 0.1, -kMaxSteerDeg, kMaxSteerDeg);
+  const uint16_t max_raw = pack_u16(steer.angle_max_deg, 0.1, 0.0, kMaxSteerDeg);
+  const int16_t request_raw = pack_i16(steer.angle_request_deg, 0.1, -kMaxSteerDeg, kMaxSteerDeg);
+  write_u16_le(frame.data, static_cast<uint16_t>(angle_raw));
+  write_u16_le(frame.data + 2, max_raw);
+  write_u16_le(frame.data + 4, static_cast<uint16_t>(request_raw));
+  return frame;
+}
+
+can_frame encode_vcu2ai_drive_front(const Vcu2AiDrive& drive) {
+  can_frame frame{};
+  frame.can_id = kMsgIdVcu2AiDriveFront;
+  frame.can_dlc = 6;
+  const int16_t trq_raw = pack_i16(drive.axle_trq_nm, 0.1, -kMaxAxleTorqueNm, kMaxAxleTorqueNm);
+  const uint16_t trq_max_raw = pack_u16(drive.axle_trq_max_nm, 0.1, 0.0, kMaxAxleTorqueNm);
+  const uint16_t trq_req_raw = pack_u16(drive.axle_trq_request_nm, 0.1, 0.0, kMaxAxleTorqueNm);
+  write_u16_le(frame.data, static_cast<uint16_t>(trq_raw));
+  write_u16_le(frame.data + 2, trq_req_raw);
+  write_u16_le(frame.data + 4, trq_max_raw);
+  return frame;
+}
+
+can_frame encode_vcu2ai_drive_rear(const Vcu2AiDrive& drive) {
+  can_frame frame{};
+  frame.can_id = kMsgIdVcu2AiDriveRear;
+  frame.can_dlc = 6;
+  const int16_t trq_raw = pack_i16(drive.axle_trq_nm, 0.1, -kMaxAxleTorqueNm, kMaxAxleTorqueNm);
+  const uint16_t trq_req_raw = pack_u16(drive.axle_trq_request_nm, 0.1, 0.0, kMaxAxleTorqueNm);
+  const uint16_t trq_max_raw = pack_u16(drive.axle_trq_max_nm, 0.1, 0.0, kMaxAxleTorqueNm);
+  write_u16_le(frame.data, static_cast<uint16_t>(trq_raw));
+  write_u16_le(frame.data + 2, trq_req_raw);
+  write_u16_le(frame.data + 4, trq_max_raw);
+  return frame;
+}
+
+can_frame encode_vcu2ai_speeds(const Vcu2AiSpeeds& speeds) {
+  can_frame frame{};
+  frame.can_id = kMsgIdVcu2AiSpeeds;
+  frame.can_dlc = 8;
+  for (int i = 0; i < 4; ++i) {
+    write_u16_le(frame.data + (i * 2), pack_u16(speeds.wheel_rpm[i], 1.0, 0.0, 1250.0));
+  }
+  return frame;
+}
+
+can_frame encode_vcu2ai_brake(const Vcu2AiBrake& brake) {
+  can_frame frame{};
+  frame.can_id = kMsgIdVcu2AiBrake;
+  frame.can_dlc = 5;
+  frame.data[0] = pack_u8(brake.front_pct, 0.5, 0.0, kMaxBrakePercent);
+  frame.data[1] = pack_u8(brake.front_req_pct, 0.5, 0.0, kMaxBrakePercent);
+  frame.data[2] = pack_u8(brake.rear_pct, 0.5, 0.0, kMaxBrakePercent);
+  frame.data[3] = pack_u8(brake.rear_req_pct, 0.5, 0.0, kMaxBrakePercent);
+  frame.data[4] = static_cast<uint8_t>(
+      (static_cast<uint8_t>(brake.status_brk) & 0xFu) |
+      ((static_cast<uint8_t>(brake.status_ebs) & 0xFu) << 4));
+  return frame;
+}
+
+can_frame encode_vcu2ai_wheel_counts(const Vcu2AiWheelCounts& counts) {
+  can_frame frame{};
+  frame.can_id = kMsgIdVcu2AiWheelCounts;
+  frame.can_dlc = 8;
+  for (int i = 0; i < 4; ++i) {
+    write_u16_le(frame.data + (i * 2), counts.pulse_count[i]);
+  }
+  return frame;
+}
+
+can_frame encode_vcu2log_dynamics1(const Vcu2LogDynamics1& dyn) {
+  can_frame frame{};
+  frame.can_id = kMsgIdVcu2LogDynamics1;
+  frame.can_dlc = 8;
+  frame.data[0] = pack_u8(dyn.speed_actual_kph, 1.0, 0.0, 255.0);
+  frame.data[1] = pack_u8(dyn.speed_target_kph, 1.0, 0.0, 255.0);
+  frame.data[2] = static_cast<uint8_t>(pack_i8(dyn.steer_actual_deg, 0.5, -64.0, 63.5));
+  frame.data[3] = static_cast<uint8_t>(pack_i8(dyn.steer_target_deg, 0.5, -64.0, 63.5));
+  frame.data[4] = pack_u8(dyn.brake_actual_pct, 1.0, 0.0, 100.0);
+  frame.data[5] = pack_u8(dyn.brake_target_pct, 1.0, 0.0, 100.0);
+  frame.data[6] = pack_u8(dyn.drive_trq_actual_pct, 1.0, 0.0, 100.0);
+  frame.data[7] = pack_u8(dyn.drive_trq_target_pct, 1.0, 0.0, 100.0);
+  return frame;
+}
+
+can_frame encode_ai2log_dynamics2(const Ai2LogDynamics2& imu) {
+  can_frame frame{};
+  frame.can_id = kMsgIdAi2LogDynamics2;
+  frame.can_dlc = 6;
+  const int16_t ax_raw = pack_i16(imu.accel_longitudinal_mps2, 0.00195313, -64.0, 63.99804688);
+  const int16_t ay_raw = pack_i16(imu.accel_lateral_mps2, 0.00195313, -64.0, 63.99804688);
+  const int16_t yaw_raw = pack_i16(imu.yaw_rate_degps, 0.0078125, -256.0, 255.9921875);
+  write_u16_le(frame.data, static_cast<uint16_t>(ax_raw));
+  write_u16_le(frame.data + 2, static_cast<uint16_t>(ay_raw));
+  write_u16_le(frame.data + 4, static_cast<uint16_t>(yaw_raw));
+  return frame;
+}
+
+}  // namespace fsai::sim::svcu::dbc

--- a/sim/svcu/adsdv_dbc.hpp
+++ b/sim/svcu/adsdv_dbc.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <linux/can.h>
+#include "can_defs.hpp"
 
 #include <cstdint>
 

--- a/sim/svcu/adsdv_dbc.hpp
+++ b/sim/svcu/adsdv_dbc.hpp
@@ -1,0 +1,177 @@
+#pragma once
+
+#include <linux/can.h>
+
+#include <cstdint>
+
+namespace fsai::sim::svcu::dbc {
+
+// Message identifiers (decimal from ADS-DV DBC)
+constexpr uint32_t kMsgIdVcu2AiStatus = 1312;
+constexpr uint32_t kMsgIdVcu2AiSteer = 1315;
+constexpr uint32_t kMsgIdVcu2AiDriveFront = 1313;
+constexpr uint32_t kMsgIdVcu2AiDriveRear = 1314;
+constexpr uint32_t kMsgIdVcu2AiSpeeds = 1317;
+constexpr uint32_t kMsgIdVcu2AiBrake = 1316;
+constexpr uint32_t kMsgIdVcu2AiWheelCounts = 1318;
+constexpr uint32_t kMsgIdVcu2LogDynamics1 = 1280;
+constexpr uint32_t kMsgIdAi2LogDynamics2 = 1281;
+
+constexpr uint32_t kMsgIdAi2VcuStatus = 1296;
+constexpr uint32_t kMsgIdAi2VcuDriveFront = 1297;
+constexpr uint32_t kMsgIdAi2VcuDriveRear = 1298;
+constexpr uint32_t kMsgIdAi2VcuSteer = 1299;
+constexpr uint32_t kMsgIdAi2VcuBrake = 1300;
+
+// Physical limits encoded in the DBC
+constexpr float kMaxSteerDeg = 21.0f;
+constexpr float kMaxAxleTorqueNm = 195.0f;
+constexpr float kMaxBrakePercent = 100.0f;
+constexpr float kDegToRad = 0.0174532925199432957692369077f;
+constexpr float kRadToDeg = 57.2957795130823208767981548f;
+
+enum class DirectionRequest : uint8_t { kNeutral = 0, kForward = 1, kReverse = 2 };
+enum class MissionStatus : uint8_t { kNotSelected = 0, kSelected = 1, kRunning = 2, kFinished = 3 };
+enum class AsState : uint8_t {
+  kOff = 1,
+  kReady = 2,
+  kDriving = 3,
+  kEmergencyBrake = 4,
+  kFinished = 5,
+  kR2d = 6
+};
+enum class SteeringStatus : uint8_t { kOff = 0, kActive = 1, kFault = 2, kUnknown = 3 };
+enum class BrakeStatus : uint8_t {
+  kInitialising = 0,
+  kReady = 1,
+  kShuttingDown = 2,
+  kShutdownComplete = 3,
+  kFault = 4
+};
+enum class EbsStatus : uint8_t { kUnavailable = 1, kArmed = 2, kTriggered = 3 };
+
+struct Ai2VcuStatus {
+  bool handshake{false};
+  bool estop_request{false};
+  MissionStatus mission_status{MissionStatus::kNotSelected};
+  DirectionRequest direction_request{DirectionRequest::kNeutral};
+  uint8_t lap_counter{0};
+  uint8_t cones_count_actual{0};
+  uint16_t cones_count_all{0};
+  float veh_speed_actual_kph{0.0f};
+  float veh_speed_demand_kph{0.0f};
+};
+
+struct Ai2VcuDrive {
+  float axle_torque_request_nm{0.0f};
+  float motor_speed_max_rpm{0.0f};
+};
+
+struct Ai2VcuSteer {
+  float steer_deg{0.0f};
+};
+
+struct Ai2VcuBrake {
+  float front_pct{0.0f};
+  float rear_pct{0.0f};
+};
+
+struct Vcu2AiStatus {
+  bool handshake{false};
+  bool shutdown_request{false};
+  bool as_switch_on{false};
+  bool ts_switch_on{false};
+  bool go_signal{false};
+  AsState as_state{AsState::kOff};
+  SteeringStatus steering_status{SteeringStatus::kOff};
+  bool fault{false};
+  bool warning{false};
+  uint8_t ami_state{0};
+  bool ai_estop_request{false};
+  bool hvil_open_fault{false};
+  bool hvil_short_fault{false};
+  bool ebs_fault{false};
+  bool offboard_charger_fault{false};
+  bool ai_comms_lost{false};
+  bool warn_batt_temp_high{false};
+  bool warn_batt_soc_low{false};
+  bool charge_procedure_fault{false};
+  bool autonomous_braking_fault{false};
+  bool mission_status_fault{false};
+  uint8_t shutdown_cause{0};
+  bool bms_fault{false};
+  bool brake_plausibility_fault{false};
+};
+
+struct Vcu2AiSteer {
+  float angle_deg{0.0f};
+  float angle_max_deg{kMaxSteerDeg};
+  float angle_request_deg{0.0f};
+};
+
+struct Vcu2AiDrive {
+  float axle_trq_nm{0.0f};
+  float axle_trq_max_nm{kMaxAxleTorqueNm};
+  float axle_trq_request_nm{0.0f};
+};
+
+struct Vcu2AiBrake {
+  float front_pct{0.0f};
+  float front_req_pct{0.0f};
+  float rear_pct{0.0f};
+  float rear_req_pct{0.0f};
+  BrakeStatus status_brk{BrakeStatus::kInitialising};
+  EbsStatus status_ebs{EbsStatus::kUnavailable};
+};
+
+struct Vcu2AiSpeeds {
+  float wheel_rpm[4]{};  // FL, FR, RL, RR
+};
+
+struct Vcu2AiWheelCounts {
+  uint16_t pulse_count[4]{};  // FL, FR, RL, RR
+};
+
+struct Vcu2LogDynamics1 {
+  float speed_actual_kph{0.0f};
+  float speed_target_kph{0.0f};
+  float steer_actual_deg{0.0f};
+  float steer_target_deg{0.0f};
+  float brake_actual_pct{0.0f};
+  float brake_target_pct{0.0f};
+  float drive_trq_actual_pct{0.0f};
+  float drive_trq_target_pct{0.0f};
+};
+
+struct Ai2LogDynamics2 {
+  float accel_longitudinal_mps2{0.0f};
+  float accel_lateral_mps2{0.0f};
+  float yaw_rate_degps{0.0f};
+};
+
+// Decode helpers for AI -> VCU traffic
+bool decode_ai2vcu_status(const can_frame& frame, Ai2VcuStatus& out);
+bool decode_ai2vcu_drive_front(const can_frame& frame, Ai2VcuDrive& out);
+bool decode_ai2vcu_drive_rear(const can_frame& frame, Ai2VcuDrive& out);
+bool decode_ai2vcu_steer(const can_frame& frame, Ai2VcuSteer& out);
+bool decode_ai2vcu_brake(const can_frame& frame, Ai2VcuBrake& out);
+
+// Encode helpers for AI -> VCU traffic (used by simulator AI loop)
+can_frame encode_ai2vcu_status(const Ai2VcuStatus& status);
+can_frame encode_ai2vcu_drive_front(const Ai2VcuDrive& drive);
+can_frame encode_ai2vcu_drive_rear(const Ai2VcuDrive& drive);
+can_frame encode_ai2vcu_steer(const Ai2VcuSteer& steer);
+can_frame encode_ai2vcu_brake(const Ai2VcuBrake& brake);
+
+// Encode helpers for VCU -> AI traffic (produced by S-VCU)
+can_frame encode_vcu2ai_status(const Vcu2AiStatus& status);
+can_frame encode_vcu2ai_steer(const Vcu2AiSteer& steer);
+can_frame encode_vcu2ai_drive_front(const Vcu2AiDrive& drive);
+can_frame encode_vcu2ai_drive_rear(const Vcu2AiDrive& drive);
+can_frame encode_vcu2ai_speeds(const Vcu2AiSpeeds& speeds);
+can_frame encode_vcu2ai_brake(const Vcu2AiBrake& brake);
+can_frame encode_vcu2ai_wheel_counts(const Vcu2AiWheelCounts& counts);
+can_frame encode_vcu2log_dynamics1(const Vcu2LogDynamics1& dyn);
+can_frame encode_ai2log_dynamics2(const Ai2LogDynamics2& imu);
+
+}  // namespace fsai::sim::svcu::dbc

--- a/sim/svcu/can_defs.hpp
+++ b/sim/svcu/can_defs.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#if __has_include(<linux/can.h>)
+#include <linux/can.h>
+#else
+#include <cstdint>
+
+struct can_frame {
+  uint32_t can_id;
+  uint8_t can_dlc;
+  uint8_t __pad;
+  uint8_t __res0;
+  uint8_t __res1;
+  uint8_t data[8];
+};
+
+#ifndef CAN_MTU
+#define CAN_MTU (sizeof(struct can_frame))
+#endif
+#ifndef CAN_MAX_DLEN
+#define CAN_MAX_DLEN 8
+#endif
+#ifndef CAN_EFF_FLAG
+#define CAN_EFF_FLAG 0x80000000U
+#endif
+#ifndef CAN_RTR_FLAG
+#define CAN_RTR_FLAG 0x40000000U
+#endif
+#ifndef CAN_ERR_FLAG
+#define CAN_ERR_FLAG 0x20000000U
+#endif
+#ifndef CAN_SFF_MASK
+#define CAN_SFF_MASK 0x000007FFU
+#endif
+#endif
+

--- a/sim/svcu/can_link.cpp
+++ b/sim/svcu/can_link.cpp
@@ -1,0 +1,235 @@
+#include "can_link.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <cstdlib>
+#include <memory>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#if defined(__linux__)
+#include "socketcan.hpp"
+#endif
+
+namespace fsai::sim::svcu {
+namespace {
+
+struct PackedCanFrame {
+  uint32_t id_be;
+  uint8_t dlc;
+  uint8_t data[CAN_MAX_DLEN];
+};
+static_assert(sizeof(PackedCanFrame) == 13, "PackedCanFrame must be 13 bytes");
+
+bool starts_with_ignore_case(const std::string& value, const char* prefix) {
+  const std::size_t prefix_len = std::strlen(prefix);
+  if (value.size() < prefix_len) {
+    return false;
+  }
+  for (std::size_t i = 0; i < prefix_len; ++i) {
+    const unsigned char lhs = static_cast<unsigned char>(value[i]);
+    const unsigned char rhs = static_cast<unsigned char>(prefix[i]);
+    if (std::tolower(lhs) != std::tolower(rhs)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+uint16_t parse_port(const std::string& text, uint16_t fallback) {
+  if (text.empty()) {
+    return fallback;
+  }
+  char* end = nullptr;
+  long value = std::strtol(text.c_str(), &end, 10);
+  if (end == text.c_str() || *end != '\0') {
+    return fallback;
+  }
+  if (value <= 0 || value > 65535) {
+    return fallback;
+  }
+  return static_cast<uint16_t>(value);
+}
+
+uint16_t extract_udp_port(const std::string& endpoint, uint16_t fallback) {
+  std::string work = endpoint;
+  if (starts_with_ignore_case(work, "udp:")) {
+    work = work.substr(4);
+    if (!work.empty() && work[0] == '/') {
+      if (work.size() > 1 && work[1] == '/') {
+        work = work.substr(2);
+      } else {
+        work = work.substr(1);
+      }
+    }
+  }
+  const auto colon_pos = work.rfind(':');
+  std::string port_str;
+  if (colon_pos != std::string::npos) {
+    port_str = work.substr(colon_pos + 1);
+  } else {
+    port_str = work;
+  }
+  std::size_t start = 0;
+  while (start < port_str.size() &&
+         std::isspace(static_cast<unsigned char>(port_str[start]))) {
+    ++start;
+  }
+  std::size_t end = port_str.size();
+  while (end > start && std::isspace(static_cast<unsigned char>(port_str[end - 1]))) {
+    --end;
+  }
+  port_str = port_str.substr(start, end - start);
+  return parse_port(port_str, fallback);
+}
+
+class UdpCanLink final : public ICanLink {
+ public:
+  UdpCanLink() = default;
+  ~UdpCanLink() override { close(); }
+
+  bool open(const std::string& endpoint, bool /*enable_loopback*/) override {
+    close();
+    port_ = extract_udp_port(endpoint, kDefaultCanUdpPort);
+
+    recv_fd_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+    if (recv_fd_ < 0) {
+      return false;
+    }
+    send_fd_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+    if (send_fd_ < 0) {
+      close();
+      return false;
+    }
+
+    int reuse = 1;
+    ::setsockopt(recv_fd_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+#if defined(SO_REUSEPORT)
+    ::setsockopt(recv_fd_, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse));
+#endif
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port_);
+    if (::bind(recv_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+      close();
+      return false;
+    }
+
+    peer_addr_ = addr;
+
+    auto set_non_blocking = [](int fd) {
+      int flags = ::fcntl(fd, F_GETFL, 0);
+      if (flags >= 0) {
+        ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+      }
+    };
+    set_non_blocking(recv_fd_);
+    set_non_blocking(send_fd_);
+
+    return true;
+  }
+
+  void close() override {
+    if (recv_fd_ >= 0) {
+      ::close(recv_fd_);
+      recv_fd_ = -1;
+    }
+    if (send_fd_ >= 0) {
+      ::close(send_fd_);
+      send_fd_ = -1;
+    }
+    port_ = 0;
+    std::memset(&peer_addr_, 0, sizeof(peer_addr_));
+  }
+
+  bool send(const can_frame& frame) override {
+    if (send_fd_ < 0) {
+      return false;
+    }
+    PackedCanFrame packed{};
+    packed.id_be = htonl(frame.can_id);
+    packed.dlc = static_cast<uint8_t>(std::min<int>(frame.can_dlc, CAN_MAX_DLEN));
+    std::memcpy(packed.data, frame.data, packed.dlc);
+    const ssize_t written = ::sendto(send_fd_, &packed, sizeof(packed), 0,
+                                     reinterpret_cast<const sockaddr*>(&peer_addr_),
+                                     sizeof(peer_addr_));
+    return written == static_cast<ssize_t>(sizeof(packed));
+  }
+
+  std::optional<can_frame> receive() override {
+    if (recv_fd_ < 0) {
+      return std::nullopt;
+    }
+    PackedCanFrame packed{};
+    sockaddr_in src{};
+    socklen_t src_len = sizeof(src);
+    const ssize_t n = ::recvfrom(recv_fd_, &packed, sizeof(packed), 0,
+                                 reinterpret_cast<sockaddr*>(&src), &src_len);
+    if (n != static_cast<ssize_t>(sizeof(packed))) {
+      return std::nullopt;
+    }
+    can_frame frame{};
+    frame.can_id = ntohl(packed.id_be);
+    frame.can_dlc = static_cast<uint8_t>(std::min<int>(packed.dlc, CAN_MAX_DLEN));
+    std::memcpy(frame.data, packed.data, frame.can_dlc);
+    return frame;
+  }
+
+ private:
+  int recv_fd_{-1};
+  int send_fd_{-1};
+  uint16_t port_{0};
+  sockaddr_in peer_addr_{};
+};
+
+}  // namespace
+
+std::unique_ptr<ICanLink> make_can_link(const std::string& endpoint_hint) {
+  const std::string canonical = canonicalize_can_endpoint(endpoint_hint);
+  if (is_udp_endpoint(canonical)) {
+    return std::make_unique<UdpCanLink>();
+  }
+#if defined(__linux__)
+  (void)canonical;
+  return std::make_unique<SocketCanLink>();
+#else
+  (void)canonical;
+  return std::make_unique<UdpCanLink>();
+#endif
+}
+
+std::string canonicalize_can_endpoint(const std::string& endpoint_hint) {
+  if (endpoint_hint.empty()) {
+#if defined(__linux__)
+    return "vcan0";
+#else
+    return "udp:" + std::to_string(kDefaultCanUdpPort);
+#endif
+  }
+  if (starts_with_ignore_case(endpoint_hint, "udp:")) {
+    const uint16_t port = extract_udp_port(endpoint_hint, kDefaultCanUdpPort);
+    return "udp:" + std::to_string(port);
+  }
+#if defined(__linux__)
+  return endpoint_hint;
+#else
+  const uint16_t port = extract_udp_port(endpoint_hint, kDefaultCanUdpPort);
+  return "udp:" + std::to_string(port);
+#endif
+}
+
+std::string default_can_endpoint() { return canonicalize_can_endpoint(""); }
+
+bool is_udp_endpoint(const std::string& endpoint) {
+  return starts_with_ignore_case(endpoint, "udp:");
+}
+
+}  // namespace fsai::sim::svcu
+

--- a/sim/svcu/can_link.cpp
+++ b/sim/svcu/can_link.cpp
@@ -19,11 +19,13 @@
 namespace fsai::sim::svcu {
 namespace {
 
+#pragma pack(push, 1)
 struct PackedCanFrame {
   uint32_t id_be;
   uint8_t dlc;
   uint8_t data[CAN_MAX_DLEN];
 };
+#pragma pack(pop)
 static_assert(sizeof(PackedCanFrame) == 13, "PackedCanFrame must be 13 bytes");
 
 bool starts_with_ignore_case(const std::string& value, const char* prefix) {

--- a/sim/svcu/can_link.hpp
+++ b/sim/svcu/can_link.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "can_defs.hpp"
+
+namespace fsai::sim::svcu {
+
+constexpr uint16_t kDefaultCanUdpPort = 47000;
+
+class ICanLink {
+ public:
+  virtual ~ICanLink() = default;
+
+  virtual bool open(const std::string& endpoint, bool enable_loopback) = 0;
+  virtual void close() = 0;
+  virtual bool send(const can_frame& frame) = 0;
+  virtual std::optional<can_frame> receive() = 0;
+};
+
+std::unique_ptr<ICanLink> make_can_link(const std::string& endpoint_hint);
+std::string canonicalize_can_endpoint(const std::string& endpoint_hint);
+std::string default_can_endpoint();
+bool is_udp_endpoint(const std::string& endpoint);
+
+}  // namespace fsai::sim::svcu
+

--- a/sim/svcu/link.cpp
+++ b/sim/svcu/link.cpp
@@ -1,0 +1,102 @@
+#include "link.hpp"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+
+namespace fsai::sim::svcu {
+
+UdpEndpoint::UdpEndpoint() : fd_(-1), connected_(false) {}
+
+UdpEndpoint::~UdpEndpoint() { close(); }
+
+bool UdpEndpoint::bind(uint16_t port) {
+  close();
+
+  fd_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+  if (fd_ < 0) {
+    return false;
+  }
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = htons(port);
+
+  if (::bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    close();
+    return false;
+  }
+
+  int flags = ::fcntl(fd_, F_GETFL, 0);
+  if (flags >= 0) {
+    ::fcntl(fd_, F_SETFL, flags | O_NONBLOCK);
+  }
+
+  connected_ = false;
+  return true;
+}
+
+bool UdpEndpoint::connect(uint16_t port, const std::string& host) {
+  close();
+
+  fd_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+  if (fd_ < 0) {
+    return false;
+  }
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  addr.sin_addr.s_addr = inet_addr(host.c_str());
+  if (addr.sin_addr.s_addr == INADDR_NONE) {
+    close();
+    return false;
+  }
+
+  if (::connect(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    close();
+    return false;
+  }
+
+  int flags = ::fcntl(fd_, F_GETFL, 0);
+  if (flags >= 0) {
+    ::fcntl(fd_, F_SETFL, flags | O_NONBLOCK);
+  }
+
+  connected_ = true;
+  return true;
+}
+
+void UdpEndpoint::close() {
+  if (fd_ >= 0) {
+    ::close(fd_);
+    fd_ = -1;
+  }
+  connected_ = false;
+}
+
+bool UdpEndpoint::send(const void* data, size_t size) const {
+  if (fd_ < 0) {
+    return false;
+  }
+  ssize_t sent = ::write(fd_, data, size);
+  return sent == static_cast<ssize_t>(size);
+}
+
+std::optional<size_t> UdpEndpoint::receive(void* data, size_t size) const {
+  if (fd_ < 0) {
+    return std::nullopt;
+  }
+  ssize_t recvd = ::read(fd_, data, size);
+  if (recvd <= 0) {
+    return std::nullopt;
+  }
+  return static_cast<size_t>(recvd);
+}
+
+}  // namespace fsai::sim::svcu

--- a/sim/svcu/link.hpp
+++ b/sim/svcu/link.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace fsai::sim::svcu {
+
+constexpr uint16_t kDefaultCommandPort = 47001;
+constexpr uint16_t kDefaultTelemetryPort = 47002;
+
+#pragma pack(push, 1)
+struct CommandPacket {
+  uint64_t t_ns;
+  float steer_rad;
+  float throttle;
+  float brake;
+  uint8_t enabled;
+  uint8_t reserved[3];
+};
+static_assert(sizeof(CommandPacket) == 24, "CommandPacket size unexpected");
+
+struct TelemetryPacket {
+  uint64_t t_ns;
+  float steer_angle_rad;
+  float front_axle_torque_nm;
+  float rear_axle_torque_nm;
+  float wheel_speed_rpm[4];
+  float brake_pressure_front_bar;
+  float brake_pressure_rear_bar;
+  float imu_ax_mps2;
+  float imu_ay_mps2;
+  float imu_yaw_rate_rps;
+  float gps_lat_deg;
+  float gps_lon_deg;
+  float gps_speed_mps;
+  uint8_t status_flags;
+  uint8_t reserved[3];
+};
+static_assert(sizeof(TelemetryPacket) == 72, "TelemetryPacket size unexpected");
+#pragma pack(pop)
+
+class UdpEndpoint {
+ public:
+  UdpEndpoint();
+  ~UdpEndpoint();
+
+  UdpEndpoint(const UdpEndpoint&) = delete;
+  UdpEndpoint& operator=(const UdpEndpoint&) = delete;
+
+  bool bind(uint16_t port);
+  bool connect(uint16_t port, const std::string& host = "127.0.0.1");
+  void close();
+
+  bool send(const void* data, size_t size) const;
+  std::optional<size_t> receive(void* data, size_t size) const;
+
+  bool valid() const { return fd_ >= 0; }
+
+ private:
+  int fd_;
+  bool connected_;
+};
+
+}  // namespace fsai::sim::svcu

--- a/sim/svcu/socketcan.cpp
+++ b/sim/svcu/socketcan.cpp
@@ -1,0 +1,89 @@
+#include "socketcan.hpp"
+
+#include <fcntl.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <iostream>
+
+namespace fsai::sim::svcu {
+
+SocketCan::SocketCan() : fd_(-1) {}
+
+SocketCan::~SocketCan() { close(); }
+
+bool SocketCan::open(const std::string& iface, bool enable_loopback) {
+  close();
+
+  fd_ = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
+  if (fd_ < 0) {
+    std::perror("socket(PF_CAN)");
+    return false;
+  }
+
+  if (!enable_loopback) {
+    int loopback = 0;
+    if (::setsockopt(fd_, SOL_CAN_RAW, CAN_RAW_LOOPBACK, &loopback,
+                     sizeof(loopback)) < 0) {
+      std::perror("setsockopt(CAN_RAW_LOOPBACK)");
+    }
+  }
+
+  struct ifreq ifr;
+  std::memset(&ifr, 0, sizeof(ifr));
+  std::snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", iface.c_str());
+
+  if (::ioctl(fd_, SIOCGIFINDEX, &ifr) < 0) {
+    std::perror("ioctl(SIOCGIFINDEX)");
+    close();
+    return false;
+  }
+
+  sockaddr_can addr{};
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (::bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    std::perror("bind(can)");
+    close();
+    return false;
+  }
+
+  int flags = ::fcntl(fd_, F_GETFL, 0);
+  if (flags >= 0) {
+    ::fcntl(fd_, F_SETFL, flags | O_NONBLOCK);
+  }
+  return true;
+}
+
+void SocketCan::close() {
+  if (fd_ >= 0) {
+    ::close(fd_);
+    fd_ = -1;
+  }
+}
+
+bool SocketCan::send(const can_frame& frame) const {
+  if (fd_ < 0) {
+    return false;
+  }
+  ssize_t n = ::write(fd_, &frame, sizeof(frame));
+  return n == sizeof(frame);
+}
+
+std::optional<can_frame> SocketCan::receive() const {
+  if (fd_ < 0) {
+    return std::nullopt;
+  }
+  can_frame frame{};
+  ssize_t n = ::read(fd_, &frame, sizeof(frame));
+  if (n == sizeof(frame)) {
+    return frame;
+  }
+  return std::nullopt;
+}
+
+}  // namespace fsai::sim::svcu

--- a/sim/svcu/socketcan.hpp
+++ b/sim/svcu/socketcan.hpp
@@ -1,26 +1,25 @@
 #pragma once
 
-#include <linux/can.h>
-#include <linux/can/raw.h>
+#include "can_link.hpp"
 
 #include <optional>
 #include <string>
 
 namespace fsai::sim::svcu {
 
-class SocketCan {
+class SocketCanLink : public ICanLink {
  public:
-  SocketCan();
-  ~SocketCan();
+  SocketCanLink();
+  ~SocketCanLink() override;
 
-  SocketCan(const SocketCan&) = delete;
-  SocketCan& operator=(const SocketCan&) = delete;
+  SocketCanLink(const SocketCanLink&) = delete;
+  SocketCanLink& operator=(const SocketCanLink&) = delete;
 
-  bool open(const std::string& iface, bool enable_loopback = false);
-  void close();
+  bool open(const std::string& iface, bool enable_loopback = false) override;
+  void close() override;
 
-  bool send(const can_frame& frame) const;
-  std::optional<can_frame> receive() const;
+  bool send(const can_frame& frame) override;
+  std::optional<can_frame> receive() override;
 
   bool valid() const { return fd_ >= 0; }
 
@@ -29,3 +28,4 @@ class SocketCan {
 };
 
 }  // namespace fsai::sim::svcu
+

--- a/sim/svcu/socketcan.hpp
+++ b/sim/svcu/socketcan.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+
+#include <optional>
+#include <string>
+
+namespace fsai::sim::svcu {
+
+class SocketCan {
+ public:
+  SocketCan();
+  ~SocketCan();
+
+  SocketCan(const SocketCan&) = delete;
+  SocketCan& operator=(const SocketCan&) = delete;
+
+  bool open(const std::string& iface, bool enable_loopback = false);
+  void close();
+
+  bool send(const can_frame& frame) const;
+  std::optional<can_frame> receive() const;
+
+  bool valid() const { return fd_ >= 0; }
+
+ private:
+  int fd_;
+};
+
+}  // namespace fsai::sim::svcu

--- a/sim/svcu/svcu_main.cpp
+++ b/sim/svcu/svcu_main.cpp
@@ -1,0 +1,464 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <csignal>
+#include <cstring>
+#include <iostream>
+#include <thread>
+
+#include "adsdv_dbc.hpp"
+#include "link.hpp"
+#include "socketcan.hpp"
+#include "VehicleParam.hpp"
+
+namespace {
+std::atomic<bool> g_running{true};
+
+void handle_signal(int) { g_running = false; }
+
+uint16_t parse_u16(const char* value, uint16_t fallback) {
+  if (!value) return fallback;
+  char* end = nullptr;
+  long v = std::strtol(value, &end, 10);
+  if (end == value || v < 0 || v > 65535) return fallback;
+  return static_cast<uint16_t>(v);
+}
+
+struct SanitizedCommand {
+  float steer_rad{0.0f};
+  float throttle{0.0f};
+  float brake{1.0f};
+  float front_torque_request_nm{0.0f};
+  float rear_torque_request_nm{0.0f};
+  float front_brake_req_pct{fsai::sim::svcu::dbc::kMaxBrakePercent};
+  float rear_brake_req_pct{fsai::sim::svcu::dbc::kMaxBrakePercent};
+  bool enabled{false};
+};
+
+class CommandAggregator {
+ public:
+  explicit CommandAggregator(const VehicleParam& params)
+      : accel_min_(static_cast<float>(params.input_ranges.acc.min)),
+        accel_max_(static_cast<float>(params.input_ranges.acc.max)),
+        steer_min_(static_cast<float>(params.input_ranges.delta.min)),
+        steer_max_(static_cast<float>(params.input_ranges.delta.max)),
+        brake_front_bias_(static_cast<float>(params.brakes.front_bias)),
+        brake_rear_bias_(static_cast<float>(params.brakes.rear_bias)),
+        brake_max_force_(static_cast<float>(params.brakes.max_force)) {
+    const float bias_sum = brake_front_bias_ + brake_rear_bias_;
+    if (bias_sum <= 0.0f) {
+      brake_front_bias_ = 0.5f;
+      brake_rear_bias_ = 0.5f;
+    } else {
+      brake_front_bias_ = std::clamp(brake_front_bias_ / bias_sum, 0.0f, 1.0f);
+      brake_rear_bias_ = 1.0f - brake_front_bias_;
+    }
+    max_throttle_ = accel_max_ > 0.0f ? std::min(accel_max_, 1.0f) : 1.0f;
+    max_brake_ = accel_min_ < 0.0f ? std::min(-accel_min_, 1.0f) : 1.0f;
+    sanitized_.brake = max_brake_;
+    sanitized_.front_brake_req_pct = sanitized_.brake * 100.0f;
+    sanitized_.rear_brake_req_pct = sanitized_.front_brake_req_pct;
+  }
+
+  void update(const fsai::sim::svcu::dbc::Ai2VcuStatus& status) {
+    status_ = status;
+    has_status_ = true;
+    recompute();
+  }
+
+  void update(const fsai::sim::svcu::dbc::Ai2VcuSteer& steer) {
+    steer_deg_ = steer.steer_deg;
+    has_steer_ = true;
+    recompute();
+  }
+
+  void updateFront(const fsai::sim::svcu::dbc::Ai2VcuDrive& drive) {
+    front_drive_ = drive;
+    has_front_drive_ = true;
+    recompute();
+  }
+
+  void updateRear(const fsai::sim::svcu::dbc::Ai2VcuDrive& drive) {
+    rear_drive_ = drive;
+    has_rear_drive_ = true;
+    recompute();
+  }
+
+  void update(const fsai::sim::svcu::dbc::Ai2VcuBrake& brake) {
+    brake_ = brake;
+    has_brake_ = true;
+    recompute();
+  }
+
+  const SanitizedCommand& sanitized() const { return sanitized_; }
+
+  bool handshake() const { return has_status_ && status_.handshake; }
+  bool estop_active() const { return has_status_ && status_.estop_request; }
+  fsai::sim::svcu::dbc::DirectionRequest direction() const {
+    return has_status_ ? status_.direction_request
+                       : fsai::sim::svcu::dbc::DirectionRequest::kNeutral;
+  }
+  fsai::sim::svcu::dbc::MissionStatus mission_status() const {
+    return has_status_ ? status_.mission_status
+                       : fsai::sim::svcu::dbc::MissionStatus::kNotSelected;
+  }
+  float brake_front_bias() const { return brake_front_bias_; }
+  float brake_rear_bias() const { return brake_rear_bias_; }
+  float brake_max_force() const { return brake_max_force_; }
+  const fsai::sim::svcu::dbc::Ai2VcuStatus& raw_status() const { return status_; }
+
+ private:
+  static float clamp01(float value) { return std::clamp(value, 0.0f, 1.0f); }
+
+  void recompute() {
+    SanitizedCommand out{};
+    out.brake = max_brake_;
+    out.front_brake_req_pct = out.brake * 100.0f;
+    out.rear_brake_req_pct = out.front_brake_req_pct;
+    out.throttle = 0.0f;
+    out.steer_rad = 0.0f;
+    out.enabled = false;
+
+    const bool handshake = has_status_ && status_.handshake;
+    const bool estop = has_status_ && status_.estop_request;
+    const bool forward = !has_status_ ||
+                         status_.direction_request ==
+                             fsai::sim::svcu::dbc::DirectionRequest::kForward;
+
+    if (handshake && forward && !estop) {
+      float steer_deg = has_steer_ ? std::clamp(steer_deg_,
+                                               -fsai::sim::svcu::dbc::kMaxSteerDeg,
+                                               fsai::sim::svcu::dbc::kMaxSteerDeg)
+                                   : 0.0f;
+      float steer_rad = steer_deg * fsai::sim::svcu::dbc::kDegToRad;
+      steer_rad = std::clamp(steer_rad, steer_min_, steer_max_);
+      out.steer_rad = steer_rad;
+
+      float front_req = has_front_drive_
+                            ? std::clamp(front_drive_.axle_torque_request_nm, 0.0f,
+                                         fsai::sim::svcu::dbc::kMaxAxleTorqueNm)
+                            : 0.0f;
+      float rear_req = has_rear_drive_
+                           ? std::clamp(rear_drive_.axle_torque_request_nm, 0.0f,
+                                        fsai::sim::svcu::dbc::kMaxAxleTorqueNm)
+                           : 0.0f;
+      float total_req = front_req + rear_req;
+      float throttle = clamp01(total_req /
+                               (2.0f * fsai::sim::svcu::dbc::kMaxAxleTorqueNm));
+      if (throttle > max_throttle_ && total_req > 0.0f) {
+        const float scale = max_throttle_ / std::max(throttle, 1e-6f);
+        front_req *= scale;
+        rear_req *= scale;
+        throttle = max_throttle_;
+      }
+      out.throttle = throttle;
+      out.front_torque_request_nm = front_req;
+      out.rear_torque_request_nm = rear_req;
+
+      float front_pct = has_brake_ ? std::clamp(brake_.front_pct, 0.0f,
+                                                fsai::sim::svcu::dbc::kMaxBrakePercent)
+                                   : 0.0f;
+      float rear_pct = has_brake_ ? std::clamp(brake_.rear_pct, 0.0f,
+                                               fsai::sim::svcu::dbc::kMaxBrakePercent)
+                                  : 0.0f;
+      float brake = clamp01(std::max(front_pct, rear_pct) / 100.0f);
+      if (brake > max_brake_ && (front_pct > 0.0f || rear_pct > 0.0f)) {
+        const float scale = (max_brake_ * 100.0f) /
+                            std::max(1.0f, std::max(front_pct, rear_pct));
+        front_pct *= scale;
+        rear_pct *= scale;
+        brake = max_brake_;
+      }
+      out.brake = brake;
+      out.front_brake_req_pct = front_pct;
+      out.rear_brake_req_pct = rear_pct;
+      out.enabled = true;
+    } else if (estop) {
+      out.brake = max_brake_;
+      out.front_brake_req_pct = fsai::sim::svcu::dbc::kMaxBrakePercent;
+      out.rear_brake_req_pct = fsai::sim::svcu::dbc::kMaxBrakePercent;
+    } else if (!handshake || !forward) {
+      out.brake = max_brake_;
+      out.front_brake_req_pct = out.brake * 100.0f;
+      out.rear_brake_req_pct = out.front_brake_req_pct;
+    }
+
+    sanitized_ = out;
+  }
+
+  float accel_min_{0.0f};
+  float accel_max_{0.0f};
+  float steer_min_{0.0f};
+  float steer_max_{0.0f};
+  float brake_front_bias_{0.5f};
+  float brake_rear_bias_{0.5f};
+  float brake_max_force_{0.0f};
+  float max_throttle_{1.0f};
+  float max_brake_{1.0f};
+
+  fsai::sim::svcu::dbc::Ai2VcuStatus status_{};
+  fsai::sim::svcu::dbc::Ai2VcuDrive front_drive_{};
+  fsai::sim::svcu::dbc::Ai2VcuDrive rear_drive_{};
+  fsai::sim::svcu::dbc::Ai2VcuBrake brake_{};
+  float steer_deg_{0.0f};
+
+  bool has_status_{false};
+  bool has_front_drive_{false};
+  bool has_rear_drive_{false};
+  bool has_brake_{false};
+  bool has_steer_{false};
+
+  SanitizedCommand sanitized_{};
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  std::signal(SIGINT, handle_signal);
+  std::signal(SIGTERM, handle_signal);
+
+  std::string vehicle_config = "../configs/vehicle/configDry.yaml";
+  std::string can_iface = "vcan0";
+  uint16_t command_port = fsai::sim::svcu::kDefaultCommandPort;
+  uint16_t telemetry_port = fsai::sim::svcu::kDefaultTelemetryPort;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--vehicle" && i + 1 < argc) {
+      vehicle_config = argv[++i];
+    } else if (arg == "--can-if" && i + 1 < argc) {
+      can_iface = argv[++i];
+    } else if (arg == "--cmd-port" && i + 1 < argc) {
+      command_port = parse_u16(argv[++i], command_port);
+    } else if (arg == "--state-port" && i + 1 < argc) {
+      telemetry_port = parse_u16(argv[++i], telemetry_port);
+    } else if (arg == "--help") {
+      std::cout << "Usage: svcu_run [--vehicle path] [--can-if iface] "
+                   "[--cmd-port port] [--state-port port]\n";
+      return 0;
+    }
+  }
+
+  VehicleParam params;
+  try {
+    params = VehicleParam::loadFromFile(vehicle_config);
+  } catch (const std::exception& e) {
+    std::cerr << "Failed to load vehicle config: " << e.what() << "\n";
+    return 1;
+  }
+
+  CommandAggregator aggregator(params);
+
+  fsai::sim::svcu::SocketCan can_bus;
+  if (!can_bus.open(can_iface)) {
+    std::cerr << "Failed to open CAN interface " << can_iface << "\n";
+    return 1;
+  }
+
+  fsai::sim::svcu::UdpEndpoint command_tx;
+  if (!command_tx.connect(command_port)) {
+    std::cerr << "Failed to connect to command port " << command_port << "\n";
+    return 1;
+  }
+
+  fsai::sim::svcu::UdpEndpoint telemetry_rx;
+  if (!telemetry_rx.bind(telemetry_port)) {
+    std::cerr << "Failed to bind telemetry port " << telemetry_port << "\n";
+    return 1;
+  }
+
+  std::cout << "S-VCU listening on CAN " << can_iface << ", command port "
+            << command_port << ", telemetry port " << telemetry_port << "\n";
+
+  fsai::sim::svcu::CommandPacket cmd_packet{};
+  fsai::sim::svcu::TelemetryPacket telemetry{};
+
+  while (g_running.load()) {
+    // Consume CAN frames from AI/Control stack.
+    while (auto frame_opt = can_bus.receive()) {
+      const auto& frame = *frame_opt;
+      switch (frame.can_id) {
+        case fsai::sim::svcu::dbc::kMsgIdAi2VcuStatus: {
+          fsai::sim::svcu::dbc::Ai2VcuStatus status{};
+          if (fsai::sim::svcu::dbc::decode_ai2vcu_status(frame, status)) {
+            aggregator.update(status);
+          }
+          break;
+        }
+        case fsai::sim::svcu::dbc::kMsgIdAi2VcuSteer: {
+          fsai::sim::svcu::dbc::Ai2VcuSteer steer{};
+          if (fsai::sim::svcu::dbc::decode_ai2vcu_steer(frame, steer)) {
+            aggregator.update(steer);
+          }
+          break;
+        }
+        case fsai::sim::svcu::dbc::kMsgIdAi2VcuDriveFront: {
+          fsai::sim::svcu::dbc::Ai2VcuDrive drive{};
+          if (fsai::sim::svcu::dbc::decode_ai2vcu_drive_front(frame, drive)) {
+            aggregator.updateFront(drive);
+          }
+          break;
+        }
+        case fsai::sim::svcu::dbc::kMsgIdAi2VcuDriveRear: {
+          fsai::sim::svcu::dbc::Ai2VcuDrive drive{};
+          if (fsai::sim::svcu::dbc::decode_ai2vcu_drive_rear(frame, drive)) {
+            aggregator.updateRear(drive);
+          }
+          break;
+        }
+        case fsai::sim::svcu::dbc::kMsgIdAi2VcuBrake: {
+          fsai::sim::svcu::dbc::Ai2VcuBrake brake{};
+          if (fsai::sim::svcu::dbc::decode_ai2vcu_brake(frame, brake)) {
+            aggregator.update(brake);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    // Send latest sanitized command to the simulator.
+    const auto now_ns = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+    const SanitizedCommand& sanitized = aggregator.sanitized();
+    cmd_packet.t_ns = now_ns;
+    cmd_packet.steer_rad = sanitized.steer_rad;
+    cmd_packet.throttle = std::clamp(sanitized.throttle, 0.0f, 1.0f);
+    cmd_packet.brake = std::clamp(sanitized.brake, 0.0f, 1.0f);
+    cmd_packet.enabled = sanitized.enabled ? 1 : 0;
+    command_tx.send(&cmd_packet, sizeof(cmd_packet));
+
+    while (auto bytes = telemetry_rx.receive(&telemetry, sizeof(telemetry))) {
+      if (*bytes != sizeof(telemetry)) {
+        continue;
+      }
+
+      const SanitizedCommand& cmd = aggregator.sanitized();
+      const bool handshake = aggregator.handshake();
+      const bool estop = aggregator.estop_active();
+      fsai::sim::svcu::dbc::Vcu2AiStatus status_msg{};
+      status_msg.handshake = handshake;
+      status_msg.shutdown_request = estop;
+      status_msg.as_switch_on = handshake;
+      status_msg.ts_switch_on = true;
+      status_msg.go_signal = cmd.enabled;
+      status_msg.as_state = estop
+                                ? fsai::sim::svcu::dbc::AsState::kEmergencyBrake
+                                : (cmd.enabled
+                                       ? fsai::sim::svcu::dbc::AsState::kDriving
+                                       : (handshake ? fsai::sim::svcu::dbc::AsState::kReady
+                                                    : fsai::sim::svcu::dbc::AsState::kOff));
+      status_msg.steering_status = cmd.enabled
+                                       ? fsai::sim::svcu::dbc::SteeringStatus::kActive
+                                       : fsai::sim::svcu::dbc::SteeringStatus::kOff;
+      status_msg.fault = estop;
+      status_msg.warning = false;
+      status_msg.ami_state = 4;  // Track drive
+      status_msg.ai_estop_request = estop;
+      status_msg.hvil_open_fault = false;
+      status_msg.hvil_short_fault = false;
+      status_msg.ebs_fault = estop;
+      status_msg.offboard_charger_fault = false;
+      status_msg.ai_comms_lost = false;
+      status_msg.warn_batt_temp_high = false;
+      status_msg.warn_batt_soc_low = false;
+      status_msg.charge_procedure_fault = false;
+      status_msg.autonomous_braking_fault = false;
+      status_msg.mission_status_fault = false;
+      status_msg.shutdown_cause = estop ? 1 : 0;
+      status_msg.bms_fault = false;
+      status_msg.brake_plausibility_fault = false;
+      can_bus.send(fsai::sim::svcu::dbc::encode_vcu2ai_status(status_msg));
+
+      fsai::sim::svcu::dbc::Vcu2AiSteer steer_msg{};
+      steer_msg.angle_deg = telemetry.steer_angle_rad * fsai::sim::svcu::dbc::kRadToDeg;
+      steer_msg.angle_max_deg = std::clamp(
+          std::abs(static_cast<float>(params.input_ranges.delta.max) *
+                   fsai::sim::svcu::dbc::kRadToDeg),
+          0.0f, fsai::sim::svcu::dbc::kMaxSteerDeg);
+      steer_msg.angle_request_deg = cmd.steer_rad * fsai::sim::svcu::dbc::kRadToDeg;
+      can_bus.send(fsai::sim::svcu::dbc::encode_vcu2ai_steer(steer_msg));
+
+      fsai::sim::svcu::dbc::Vcu2AiDrive front_drive{};
+      front_drive.axle_trq_nm = telemetry.front_axle_torque_nm;
+      front_drive.axle_trq_request_nm = cmd.front_torque_request_nm;
+      front_drive.axle_trq_max_nm = fsai::sim::svcu::dbc::kMaxAxleTorqueNm;
+      can_bus.send(fsai::sim::svcu::dbc::encode_vcu2ai_drive_front(front_drive));
+
+      fsai::sim::svcu::dbc::Vcu2AiDrive rear_drive{};
+      rear_drive.axle_trq_nm = telemetry.rear_axle_torque_nm;
+      rear_drive.axle_trq_request_nm = cmd.rear_torque_request_nm;
+      rear_drive.axle_trq_max_nm = fsai::sim::svcu::dbc::kMaxAxleTorqueNm;
+      can_bus.send(fsai::sim::svcu::dbc::encode_vcu2ai_drive_rear(rear_drive));
+
+      fsai::sim::svcu::dbc::Vcu2AiSpeeds speed_msg{};
+      for (int i = 0; i < 4; ++i) {
+        speed_msg.wheel_rpm[i] = telemetry.wheel_speed_rpm[i];
+      }
+      can_bus.send(fsai::sim::svcu::dbc::encode_vcu2ai_speeds(speed_msg));
+
+      const double front_bias = std::max(0.0f, aggregator.brake_front_bias());
+      const double rear_bias = std::max(0.0f, aggregator.brake_rear_bias());
+      const double front_force_max = std::max(1.0, aggregator.brake_max_force() * front_bias);
+      const double rear_force_max = std::max(1.0, aggregator.brake_max_force() * rear_bias);
+      const double front_force_N = telemetry.brake_pressure_front_bar * 1000.0;
+      const double rear_force_N = telemetry.brake_pressure_rear_bar * 1000.0;
+      const float front_actual_pct = std::clamp(
+          static_cast<float>((front_force_N / front_force_max) * 100.0), 0.0f,
+          fsai::sim::svcu::dbc::kMaxBrakePercent);
+      const float rear_actual_pct = std::clamp(
+          static_cast<float>((rear_force_N / rear_force_max) * 100.0), 0.0f,
+          fsai::sim::svcu::dbc::kMaxBrakePercent);
+
+      fsai::sim::svcu::dbc::Vcu2AiBrake brake_msg{};
+      brake_msg.front_pct = front_actual_pct;
+      brake_msg.rear_pct = rear_actual_pct;
+      brake_msg.front_req_pct = cmd.front_brake_req_pct;
+      brake_msg.rear_req_pct = cmd.rear_brake_req_pct;
+      brake_msg.status_brk = estop ? fsai::sim::svcu::dbc::BrakeStatus::kFault
+                                   : (handshake
+                                          ? fsai::sim::svcu::dbc::BrakeStatus::kReady
+                                          : fsai::sim::svcu::dbc::BrakeStatus::kInitialising);
+      brake_msg.status_ebs = estop
+                                 ? fsai::sim::svcu::dbc::EbsStatus::kTriggered
+                                 : (handshake
+                                        ? fsai::sim::svcu::dbc::EbsStatus::kArmed
+                                        : fsai::sim::svcu::dbc::EbsStatus::kUnavailable);
+      can_bus.send(fsai::sim::svcu::dbc::encode_vcu2ai_brake(brake_msg));
+
+      fsai::sim::svcu::dbc::Vcu2LogDynamics1 dyn{};
+      dyn.speed_actual_kph = telemetry.gps_speed_mps * 3.6f;
+      dyn.speed_target_kph = aggregator.raw_status().veh_speed_demand_kph;
+      dyn.steer_actual_deg = steer_msg.angle_deg;
+      dyn.steer_target_deg = steer_msg.angle_request_deg;
+      dyn.brake_actual_pct = std::clamp(std::max(front_actual_pct, rear_actual_pct),
+                                        0.0f, fsai::sim::svcu::dbc::kMaxBrakePercent);
+      dyn.brake_target_pct = std::clamp(
+          std::max(cmd.front_brake_req_pct, cmd.rear_brake_req_pct), 0.0f,
+          fsai::sim::svcu::dbc::kMaxBrakePercent);
+      dyn.drive_trq_actual_pct = std::clamp(
+          static_cast<float>((std::max(0.0f, telemetry.front_axle_torque_nm) +
+                              std::max(0.0f, telemetry.rear_axle_torque_nm)) /
+                             (2.0f * fsai::sim::svcu::dbc::kMaxAxleTorqueNm) *
+                             100.0f),
+          0.0f, 100.0f);
+      dyn.drive_trq_target_pct = std::clamp(cmd.throttle * 100.0f, 0.0f, 100.0f);
+      can_bus.send(fsai::sim::svcu::dbc::encode_vcu2log_dynamics1(dyn));
+
+      fsai::sim::svcu::dbc::Ai2LogDynamics2 imu{};
+      imu.accel_longitudinal_mps2 = telemetry.imu_ax_mps2;
+      imu.accel_lateral_mps2 = telemetry.imu_ay_mps2;
+      imu.yaw_rate_degps = telemetry.imu_yaw_rate_rps * fsai::sim::svcu::dbc::kRadToDeg;
+      can_bus.send(fsai::sim::svcu::dbc::encode_ai2log_dynamics2(imu));
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  std::cout << "S-VCU shutting down." << std::endl;
+  return 0;
+}

--- a/tools/scripts/run_sim_with_svcu.sh
+++ b/tools/scripts/run_sim_with_svcu.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CAN_IFACE=${CAN_IFACE:-vcan0}
+BUILD_DIR=${BUILD_DIR:-build}
+CMD_PORT=${CMD_PORT:-47001}
+STATE_PORT=${STATE_PORT:-47002}
+
+function ensure_vcan() {
+  if ip link show "$CAN_IFACE" > /dev/null 2>&1; then
+    return
+  fi
+  if ! command -v sudo > /dev/null 2>&1; then
+    echo "sudo is required to create $CAN_IFACE" >&2
+    exit 1
+  fi
+  echo "Creating $CAN_IFACE (requires sudo)"
+  sudo modprobe vcan
+  sudo ip link add dev "$CAN_IFACE" type vcan
+  sudo ip link set up "$CAN_IFACE"
+}
+
+ensure_vcan
+
+FSAI_RUN="$BUILD_DIR/fsai_run"
+SVCU_RUN="$BUILD_DIR/svcu_run"
+
+if [[ ! -x "$FSAI_RUN" || ! -x "$SVCU_RUN" ]]; then
+  echo "Expected executables in $BUILD_DIR. Build the project before running." >&2
+  exit 1
+fi
+
+trap 'kill 0' INT TERM
+
+"$SVCU_RUN" --can-if "$CAN_IFACE" --cmd-port "$CMD_PORT" --state-port "$STATE_PORT" &
+SVCU_PID=$!
+
+echo "S-VCU started (pid=$SVCU_PID)"
+
+"$FSAI_RUN" --can-if "$CAN_IFACE" --cmd-port "$CMD_PORT" --state-port "$STATE_PORT"
+
+wait "$SVCU_PID"

--- a/tools/scripts/run_sim_with_svcu.sh
+++ b/tools/scripts/run_sim_with_svcu.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CAN_IFACE=${CAN_IFACE:-vcan0}
+OS_NAME=$(uname -s)
+DEFAULT_UDP_PORT=${CAN_UDP_PORT:-47000}
+
+if [[ "$OS_NAME" == "Darwin" ]]; then
+  CAN_IFACE=${CAN_IFACE:-udp:$DEFAULT_UDP_PORT}
+else
+  CAN_IFACE=${CAN_IFACE:-vcan0}
+fi
+
 BUILD_DIR=${BUILD_DIR:-build}
 CMD_PORT=${CMD_PORT:-47001}
 STATE_PORT=${STATE_PORT:-47002}
@@ -20,7 +28,9 @@ function ensure_vcan() {
   sudo ip link set up "$CAN_IFACE"
 }
 
-ensure_vcan
+if [[ "$OS_NAME" != "Darwin" ]]; then
+  ensure_vcan
+fi
 
 FSAI_RUN="$BUILD_DIR/fsai_run"
 SVCU_RUN="$BUILD_DIR/svcu_run"


### PR DESCRIPTION
## Summary
- replace the ad-hoc CAN schema with ADS-DV DBC message ids, limits, and encode/decode helpers for AI↔VCU and telemetry traffic
- rework the S-VCU bridge to aggregate AI commands, clamp them against vehicle limits, and emit status, torque, brake, speed, and IMU frames per the DBC
- update the simulator loop to publish AI→VCU status, steer, drive, and brake requests using the configured vehicle parameters

## Testing
- cmake -S . -B build *(fails: Eigen3Config.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fa8ab20c4883248a65cd23c28b0ec4