### PR TITLE
Add CAN runtime adapter and integrate control loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,20 @@ file(GLOB_RECURSE SIM_APP_SOURCES CONFIGURE_DEPENDS
 add_executable(fsai_run ${SIM_APP_SOURCES})
 target_link_libraries(fsai_run PRIVATE fsai_sim fsai_rendering)
 
+file(GLOB_RECURSE CONTROL_RUNTIME_SOURCES CONFIGURE_DEPENDS
+  "${CMAKE_SOURCE_DIR}/control/runtime_cpp/*.cpp"
+)
+
+if(CONTROL_RUNTIME_SOURCES)
+  add_library(fsai_control_runtime STATIC ${CONTROL_RUNTIME_SOURCES})
+  target_include_directories(fsai_control_runtime PUBLIC ${HEADER_DIRS})
+  target_link_libraries(fsai_control_runtime PUBLIC fsai_sim)
+  if(UNIX)
+    target_link_libraries(fsai_control_runtime PUBLIC dl)
+  endif()
+  target_link_libraries(fsai_run PRIVATE fsai_control_runtime)
+endif()
+
 add_executable(svcu_run sim/svcu/svcu_main.cpp)
 target_link_libraries(svcu_run PRIVATE fsai_sim)
 

--- a/control/runtime_cpp/ai2vcu_adapter.cpp
+++ b/control/runtime_cpp/ai2vcu_adapter.cpp
@@ -1,0 +1,71 @@
+#include "ai2vcu_adapter.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace fsai::control::runtime {
+namespace {
+constexpr float kEpsilon = 1e-6f;
+}
+
+Ai2VcuAdapter::Ai2VcuAdapter(const Ai2VcuAdapterConfig& config)
+    : config_(config) {
+  const float motor_sum = std::max(kEpsilon, config_.front_motor_weight + config_.rear_motor_weight);
+  config_.front_motor_weight = std::clamp(config_.front_motor_weight / motor_sum, 0.0f, 1.0f);
+  config_.rear_motor_weight = std::clamp(config_.rear_motor_weight / motor_sum, 0.0f, 1.0f);
+
+  const float brake_sum = std::max(kEpsilon, config_.brake_front_bias + config_.brake_rear_bias);
+  config_.brake_front_bias = std::clamp(config_.brake_front_bias / brake_sum, 0.0f, 1.0f);
+  config_.brake_rear_bias = std::clamp(1.0f - config_.brake_front_bias, 0.0f, 1.0f);
+
+  status_.handshake = true;
+  status_.mission_status = fsai::sim::svcu::dbc::MissionStatus::kSelected;
+  status_.direction_request = fsai::sim::svcu::dbc::DirectionRequest::kForward;
+  status_.veh_speed_actual_kph = 0.0f;
+  status_.veh_speed_demand_kph = 0.0f;
+}
+
+Ai2VcuCommandSet Ai2VcuAdapter::Adapt(const fsai::types::ControlCmd& cmd,
+                                      float measured_speed_mps,
+                                      bool mission_running,
+                                      uint8_t lap_counter) {
+  Ai2VcuCommandSet out{};
+
+  const float throttle = std::clamp(cmd.throttle, 0.0f, 1.0f);
+  const float brake = std::clamp(cmd.brake, 0.0f, 1.0f);
+  out.throttle_clamped = throttle;
+  out.brake_clamped = brake;
+
+  status_.mission_status = mission_running ? fsai::sim::svcu::dbc::MissionStatus::kRunning
+                                           : fsai::sim::svcu::dbc::MissionStatus::kSelected;
+  status_.estop_request = false;
+  status_.lap_counter = static_cast<uint8_t>(lap_counter & 0x0Fu);
+  status_.veh_speed_actual_kph = std::clamp(measured_speed_mps * 3.6f, 0.0f, 255.0f);
+  status_.veh_speed_demand_kph = std::clamp(config_.max_speed_kph * throttle, 0.0f, 255.0f);
+  out.status = status_;
+
+  const float steer_deg = std::clamp(cmd.steer_rad * fsai::sim::svcu::dbc::kRadToDeg,
+                                     -fsai::sim::svcu::dbc::kMaxSteerDeg,
+                                     fsai::sim::svcu::dbc::kMaxSteerDeg);
+  out.steer.steer_deg = steer_deg;
+
+  const float total_torque_nm = throttle * 2.0f * fsai::sim::svcu::dbc::kMaxAxleTorqueNm;
+  out.front_drive.axle_torque_request_nm =
+      std::clamp(total_torque_nm * config_.front_motor_weight, 0.0f,
+                 fsai::sim::svcu::dbc::kMaxAxleTorqueNm);
+  out.rear_drive.axle_torque_request_nm =
+      std::clamp(total_torque_nm * config_.rear_motor_weight, 0.0f,
+                 fsai::sim::svcu::dbc::kMaxAxleTorqueNm);
+  out.front_drive.motor_speed_max_rpm = config_.motor_speed_max_rpm;
+  out.rear_drive.motor_speed_max_rpm = config_.motor_speed_max_rpm;
+
+  const float brake_pct = brake * fsai::sim::svcu::dbc::kMaxBrakePercent;
+  out.brake.front_pct = std::clamp(brake_pct * config_.brake_front_bias, 0.0f,
+                                   fsai::sim::svcu::dbc::kMaxBrakePercent);
+  out.brake.rear_pct = std::clamp(brake_pct * config_.brake_rear_bias, 0.0f,
+                                  fsai::sim::svcu::dbc::kMaxBrakePercent);
+
+  return out;
+}
+
+}  // namespace fsai::control::runtime

--- a/control/runtime_cpp/ai2vcu_adapter.hpp
+++ b/control/runtime_cpp/ai2vcu_adapter.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+
+#include "adsdv_dbc.hpp"
+#include "types.h"
+
+namespace fsai::control::runtime {
+
+struct Ai2VcuAdapterConfig {
+  float front_motor_weight{0.5f};
+  float rear_motor_weight{0.5f};
+  float brake_front_bias{0.5f};
+  float brake_rear_bias{0.5f};
+  float max_speed_kph{120.0f};
+  float motor_speed_max_rpm{4000.0f};
+};
+
+struct Ai2VcuCommandSet {
+  fsai::sim::svcu::dbc::Ai2VcuStatus status;
+  fsai::sim::svcu::dbc::Ai2VcuSteer steer;
+  fsai::sim::svcu::dbc::Ai2VcuDrive front_drive;
+  fsai::sim::svcu::dbc::Ai2VcuDrive rear_drive;
+  fsai::sim::svcu::dbc::Ai2VcuBrake brake;
+  float throttle_clamped{0.0f};
+  float brake_clamped{0.0f};
+};
+
+class Ai2VcuAdapter {
+ public:
+  explicit Ai2VcuAdapter(const Ai2VcuAdapterConfig& config);
+
+  Ai2VcuCommandSet Adapt(const fsai::types::ControlCmd& cmd,
+                         float measured_speed_mps,
+                         bool mission_running,
+                         uint8_t lap_counter);
+
+ private:
+  Ai2VcuAdapterConfig config_;
+  fsai::sim::svcu::dbc::Ai2VcuStatus status_{};
+};
+
+}  // namespace fsai::control::runtime

--- a/control/runtime_cpp/can_iface.cpp
+++ b/control/runtime_cpp/can_iface.cpp
@@ -1,0 +1,324 @@
+#include "can_iface.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <dlfcn.h>
+#endif
+
+namespace fsai::control::runtime {
+namespace {
+constexpr float kDegToRad = fsai::sim::svcu::dbc::kDegToRad;
+constexpr float kRadToDeg = fsai::sim::svcu::dbc::kRadToDeg;
+
+struct FsAiApiAi2VcuData {
+  fsai::sim::svcu::dbc::Ai2VcuStatus status;
+  fsai::sim::svcu::dbc::Ai2VcuSteer steer;
+  fsai::sim::svcu::dbc::Ai2VcuDrive front_drive;
+  fsai::sim::svcu::dbc::Ai2VcuDrive rear_drive;
+  fsai::sim::svcu::dbc::Ai2VcuBrake brake;
+};
+
+struct FsAiApiVcu2AiData {
+  fsai::sim::svcu::dbc::Vcu2AiStatus status;
+  fsai::sim::svcu::dbc::Vcu2AiSteer steer;
+  fsai::sim::svcu::dbc::Vcu2AiDrive front_drive;
+  fsai::sim::svcu::dbc::Vcu2AiDrive rear_drive;
+  fsai::sim::svcu::dbc::Vcu2AiBrake brake;
+  fsai::sim::svcu::dbc::Vcu2AiSpeeds speeds;
+  fsai::sim::svcu::dbc::Vcu2LogDynamics1 dynamics;
+};
+
+struct FsAiApiImuData {
+  float accel_longitudinal_mps2;
+  float accel_lateral_mps2;
+  float yaw_rate_degps;
+};
+
+struct FsAiApiGpsData {
+  double lat_deg;
+  double lon_deg;
+  double speed_mps;
+};
+}  // namespace
+
+struct CanIface::FsAiApiVtable {
+#if defined(__unix__) || defined(__APPLE__)
+  void* handle{nullptr};
+#endif
+  int (*init_fn)(const char*){nullptr};
+  int (*set_fn)(const FsAiApiAi2VcuData*){nullptr};
+  int (*get_fn)(FsAiApiVcu2AiData*){nullptr};
+  int (*imu_fn)(FsAiApiImuData*){nullptr};
+  int (*gps_fn)(FsAiApiGpsData*){nullptr};
+};
+
+CanIface::CanIface() = default;
+CanIface::~CanIface() { Shutdown(); }
+
+bool CanIface::Initialize(const Config& config) {
+  Shutdown();
+  mode_ = config.mode;
+  initialized_ = false;
+
+  switch (mode_) {
+    case Mode::kSimulation:
+      if (!InitializeSimulation(config)) {
+        return false;
+      }
+      break;
+    case Mode::kFsAiApi:
+      if (!InitializeFsAiApi(config)) {
+        return false;
+      }
+      break;
+  }
+
+  initialized_ = true;
+  return true;
+}
+
+void CanIface::Shutdown() {
+  if (!initialized_) {
+    return;
+  }
+
+  if (mode_ == Mode::kSimulation && sim_link_) {
+    sim_link_->close();
+    sim_link_.reset();
+  }
+
+#if defined(__unix__) || defined(__APPLE__)
+  if (api_) {
+    if (api_->handle) {
+      dlclose(api_->handle);
+    }
+  }
+#endif
+  api_.reset();
+  initialized_ = false;
+}
+
+bool CanIface::Send(const Ai2VcuCommandSet& commands) {
+  if (!initialized_) {
+    return false;
+  }
+
+  if (mode_ == Mode::kSimulation) {
+    if (!sim_link_) {
+      return false;
+    }
+    const auto send_frame = [this](const can_frame& frame) {
+      if (!sim_link_->send(frame)) {
+        std::fprintf(stderr, "[CanIface] Failed to send CAN frame id=%u\n", frame.can_id);
+      }
+    };
+    send_frame(fsai::sim::svcu::dbc::encode_ai2vcu_status(commands.status));
+    send_frame(fsai::sim::svcu::dbc::encode_ai2vcu_steer(commands.steer));
+    send_frame(fsai::sim::svcu::dbc::encode_ai2vcu_drive_front(commands.front_drive));
+    send_frame(fsai::sim::svcu::dbc::encode_ai2vcu_drive_rear(commands.rear_drive));
+    send_frame(fsai::sim::svcu::dbc::encode_ai2vcu_brake(commands.brake));
+    return true;
+  }
+
+  if (!api_) {
+    return false;
+  }
+
+  if (!api_->set_fn) {
+    return false;
+  }
+  FsAiApiAi2VcuData payload{};
+  payload.status = commands.status;
+  payload.steer = commands.steer;
+  payload.front_drive = commands.front_drive;
+  payload.rear_drive = commands.rear_drive;
+  payload.brake = commands.brake;
+  return api_->set_fn(&payload) == 0;
+}
+
+void CanIface::Poll(uint64_t now_ns) {
+  if (!initialized_) {
+    return;
+  }
+  last_feedback_ns_ = now_ns;
+  if (mode_ == Mode::kSimulation) {
+    PollSimulation();
+  } else {
+    PollFsAiApi();
+  }
+}
+
+std::optional<fsai::types::VehicleState> CanIface::LatestVehicleState() const {
+  if (!initialized_ || !has_dyn_) {
+    return std::nullopt;
+  }
+  fsai::types::VehicleState state{};
+  state.t_ns = last_feedback_ns_;
+  state.x = 0.0f;
+  state.y = 0.0f;
+  state.yaw = 0.0f;
+  state.vx = feedback_dyn_.speed_actual_kph / 3.6f;
+  state.vy = 0.0f;
+  state.yaw_rate = has_imu_ ? feedback_imu_.yaw_rate_degps * kDegToRad : 0.0f;
+  state.ax = has_imu_ ? feedback_imu_.accel_longitudinal_mps2 : 0.0f;
+  state.ay = has_imu_ ? feedback_imu_.accel_lateral_mps2 : 0.0f;
+  state.steer_rad = feedback_steer_.angle_deg * kDegToRad;
+  return state;
+}
+
+std::optional<ImuSample> CanIface::LatestImu() const {
+  if (!initialized_ || !has_imu_) {
+    return std::nullopt;
+  }
+  ImuSample imu{};
+  imu.accel_longitudinal_mps2 = feedback_imu_.accel_longitudinal_mps2;
+  imu.accel_lateral_mps2 = feedback_imu_.accel_lateral_mps2;
+  imu.yaw_rate_rps = feedback_imu_.yaw_rate_degps * kDegToRad;
+  return imu;
+}
+
+std::optional<GpsSample> CanIface::LatestGps() const {
+  if (!initialized_ || !has_dyn_) {
+    return std::nullopt;
+  }
+  GpsSample gps{};
+  gps.lat_deg = 0.0;
+  gps.lon_deg = 0.0;
+  gps.speed_mps = feedback_dyn_.speed_actual_kph / 3.6f;
+  return gps;
+}
+
+bool CanIface::InitializeSimulation(const Config& config) {
+  auto link = fsai::sim::svcu::make_can_link(config.endpoint);
+  if (!link) {
+    std::fprintf(stderr, "[CanIface] Failed to create CAN link for %s\n", config.endpoint.c_str());
+    return false;
+  }
+  if (!link->open(config.endpoint, config.enable_loopback)) {
+    std::fprintf(stderr, "[CanIface] Failed to open CAN endpoint %s\n", config.endpoint.c_str());
+    return false;
+  }
+  sim_link_ = std::move(link);
+  has_status_ = false;
+  has_dyn_ = false;
+  has_imu_ = false;
+  return true;
+}
+
+bool CanIface::InitializeFsAiApi(const Config& config) {
+#if defined(__unix__) || defined(__APPLE__)
+  api_ = std::make_unique<FsAiApiVtable>();
+  const std::string library_path = !config.api_library.empty() ? config.api_library
+                                                              : "libfs_ai_api.so";
+  api_->handle = dlopen(library_path.c_str(), RTLD_LAZY);
+  if (!api_->handle) {
+    std::fprintf(stderr, "[CanIface] Failed to load %s: %s\n", library_path.c_str(), dlerror());
+    return false;
+  }
+  api_->init_fn = reinterpret_cast<int (*)(const char*)>(dlsym(api_->handle, "fs_ai_api_init"));
+  api_->set_fn = reinterpret_cast<int (*)(const FsAiApiAi2VcuData*)>(
+      dlsym(api_->handle, "fs_ai_api_ai2vcu_set_data"));
+  api_->get_fn = reinterpret_cast<int (*)(FsAiApiVcu2AiData*)>(
+      dlsym(api_->handle, "fs_ai_api_vcu2ai_get_data"));
+  api_->imu_fn = reinterpret_cast<int (*)(FsAiApiImuData*)>(
+      dlsym(api_->handle, "fs_ai_api_imu_get_data"));
+  api_->gps_fn = reinterpret_cast<int (*)(FsAiApiGpsData*)>(
+      dlsym(api_->handle, "fs_ai_api_gps_get_data"));
+  if (!api_->init_fn || !api_->set_fn || !api_->get_fn) {
+    std::fprintf(stderr, "[CanIface] Missing functions in FS-AI API library\n");
+    return false;
+  }
+  if (api_->init_fn(config.endpoint.c_str()) != 0) {
+    std::fprintf(stderr, "[CanIface] fs_ai_api_init failed for %s\n", config.endpoint.c_str());
+    return false;
+  }
+  return true;
+#else
+  (void)config;
+  std::fprintf(stderr, "[CanIface] FS-AI API mode not supported on this platform\n");
+  return false;
+#endif
+}
+
+void CanIface::PollSimulation() {
+  if (!sim_link_) {
+    return;
+  }
+  while (auto frame = sim_link_->receive()) {
+    fsai::sim::svcu::dbc::Vcu2AiStatus status{};
+    fsai::sim::svcu::dbc::Vcu2AiSteer steer{};
+    fsai::sim::svcu::dbc::Vcu2AiDrive drive{};
+    fsai::sim::svcu::dbc::Vcu2AiBrake brake{};
+    fsai::sim::svcu::dbc::Vcu2LogDynamics1 dyn{};
+    fsai::sim::svcu::dbc::Ai2LogDynamics2 imu{};
+    if (fsai::sim::svcu::dbc::decode_vcu2ai_status(*frame, status)) {
+      feedback_status_ = status;
+      has_status_ = true;
+      continue;
+    }
+    if (fsai::sim::svcu::dbc::decode_vcu2ai_steer(*frame, steer)) {
+      feedback_steer_ = steer;
+      continue;
+    }
+    if (fsai::sim::svcu::dbc::decode_vcu2ai_drive_front(*frame, drive)) {
+      feedback_front_drive_ = drive;
+      continue;
+    }
+    if (fsai::sim::svcu::dbc::decode_vcu2ai_drive_rear(*frame, drive)) {
+      feedback_rear_drive_ = drive;
+      continue;
+    }
+    if (fsai::sim::svcu::dbc::decode_vcu2ai_brake(*frame, brake)) {
+      feedback_brake_ = brake;
+      continue;
+    }
+    if (fsai::sim::svcu::dbc::decode_vcu2log_dynamics1(*frame, dyn)) {
+      feedback_dyn_ = dyn;
+      has_dyn_ = true;
+      continue;
+    }
+    if (fsai::sim::svcu::dbc::decode_ai2log_dynamics2(*frame, imu)) {
+      feedback_imu_ = imu;
+      has_imu_ = true;
+      continue;
+    }
+  }
+}
+
+void CanIface::PollFsAiApi() {
+  if (!api_ || !api_->get_fn) {
+    return;
+  }
+  FsAiApiVcu2AiData feedback{};
+  if (api_->get_fn(&feedback) == 0) {
+    feedback_status_ = feedback.status;
+    feedback_steer_ = feedback.steer;
+    feedback_front_drive_ = feedback.front_drive;
+    feedback_rear_drive_ = feedback.rear_drive;
+    feedback_brake_ = feedback.brake;
+    feedback_dyn_ = feedback.dynamics;
+    has_status_ = true;
+    has_dyn_ = true;
+  }
+  if (api_->imu_fn) {
+    FsAiApiImuData imu{};
+    if (api_->imu_fn(&imu) == 0) {
+      feedback_imu_.accel_longitudinal_mps2 = imu.accel_longitudinal_mps2;
+      feedback_imu_.accel_lateral_mps2 = imu.accel_lateral_mps2;
+      feedback_imu_.yaw_rate_degps = imu.yaw_rate_degps;
+      has_imu_ = true;
+    }
+  }
+  if (api_->gps_fn) {
+    FsAiApiGpsData gps{};
+    if (api_->gps_fn(&gps) == 0) {
+      feedback_dyn_.speed_actual_kph = static_cast<float>(std::max(0.0, gps.speed_mps) * 3.6);
+      has_dyn_ = true;
+    }
+  }
+}
+
+}  // namespace fsai::control::runtime

--- a/sim/svcu/adsdv_dbc.hpp
+++ b/sim/svcu/adsdv_dbc.hpp
@@ -156,6 +156,14 @@ bool decode_ai2vcu_drive_rear(const can_frame& frame, Ai2VcuDrive& out);
 bool decode_ai2vcu_steer(const can_frame& frame, Ai2VcuSteer& out);
 bool decode_ai2vcu_brake(const can_frame& frame, Ai2VcuBrake& out);
 
+bool decode_vcu2ai_status(const can_frame& frame, Vcu2AiStatus& out);
+bool decode_vcu2ai_steer(const can_frame& frame, Vcu2AiSteer& out);
+bool decode_vcu2ai_drive_front(const can_frame& frame, Vcu2AiDrive& out);
+bool decode_vcu2ai_drive_rear(const can_frame& frame, Vcu2AiDrive& out);
+bool decode_vcu2ai_brake(const can_frame& frame, Vcu2AiBrake& out);
+bool decode_vcu2log_dynamics1(const can_frame& frame, Vcu2LogDynamics1& out);
+bool decode_ai2log_dynamics2(const can_frame& frame, Ai2LogDynamics2& out);
+
 // Encode helpers for AI -> VCU traffic (used by simulator AI loop)
 can_frame encode_ai2vcu_status(const Ai2VcuStatus& status);
 can_frame encode_ai2vcu_drive_front(const Ai2VcuDrive& drive);


### PR DESCRIPTION
## Summary
- add a runtime CAN interface and Ai2Vcu adapter that wrap the FS-AI API entry points
- extend the DBC helper with decode utilities so the runtime can consume VCU feedback
- update the simulator control loop to use the new interface, support a mode flag, and pace CAN traffic at 10 ms while wiring the new runtime library into CMake

## Testing
- `cmake -S . -B build` *(fails: Eigen3 package not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb469d31f48324b82c676eec34c470