### PR TITLE
Simulate VCU telemetry feedback with configurable sensor noise

### DIFF
--- a/configs/sim/sensors.yaml
+++ b/configs/sim/sensors.yaml
@@ -1,0 +1,37 @@
+# Sensor noise and latency configuration for simulated CAN feedback.
+# Latencies are specified in milliseconds; noise values are standard deviations
+# in the units noted for each channel.
+seed: 1337
+
+steering:
+  noise_std_deg: 0.0
+  latency_ms: 0.0
+
+wheel_speed:
+  noise_std_rpm: 0.0
+  latency_ms: 0.0
+
+drive_torque:
+  front_noise_std_nm: 0.0
+  rear_noise_std_nm: 0.0
+  latency_ms: 0.0
+
+brake:
+  noise_std_pct: 0.0
+  latency_ms: 0.0
+
+speed:
+  noise_std_kph: 0.0
+  latency_ms: 0.0
+
+imu:
+  noise_std_ax: 0.0
+  noise_std_ay: 0.0
+  noise_std_yaw_degps: 0.0
+  latency_ms: 0.0
+
+gps:
+  noise_std_lat_deg: 0.0
+  noise_std_lon_deg: 0.0
+  noise_std_speed_mps: 0.0
+  latency_ms: 0.0

--- a/control/runtime_cpp/can_iface.hpp
+++ b/control/runtime_cpp/can_iface.hpp
@@ -33,6 +33,7 @@ class CanIface {
     std::string endpoint;
     bool enable_loopback{true};
     std::string api_library;
+    double wheel_radius_m{0.25};
   };
 
   CanIface();
@@ -43,6 +44,9 @@ class CanIface {
 
   bool Send(const Ai2VcuCommandSet& commands);
   void Poll(uint64_t now_ns);
+
+  bool SendSimulationFrame(const can_frame& frame);
+  void SetSimulationGpsSample(double lat_deg, double lon_deg, double speed_mps);
 
   std::optional<fsai::types::VehicleState> LatestVehicleState() const;
   std::optional<ImuSample> LatestImu() const;
@@ -60,10 +64,12 @@ class CanIface {
   bool InitializeFsAiApi(const Config& config);
   void PollSimulation();
   void PollFsAiApi();
+  void ProcessFrame(const can_frame& frame);
 
   Mode mode_{Mode::kSimulation};
   bool initialized_{false};
   std::unique_ptr<fsai::sim::svcu::ICanLink> sim_link_;
+  double wheel_radius_m_{0.25};
 
   fsai::sim::svcu::dbc::Vcu2AiStatus feedback_status_{};
   fsai::sim::svcu::dbc::Vcu2AiSteer feedback_steer_{};
@@ -72,10 +78,16 @@ class CanIface {
   fsai::sim::svcu::dbc::Vcu2AiBrake feedback_brake_{};
   fsai::sim::svcu::dbc::Vcu2LogDynamics1 feedback_dyn_{};
   fsai::sim::svcu::dbc::Ai2LogDynamics2 feedback_imu_{};
+  fsai::sim::svcu::dbc::Vcu2AiSpeeds feedback_speeds_{};
   uint64_t last_feedback_ns_{0};
   bool has_status_{false};
   bool has_dyn_{false};
   bool has_imu_{false};
+  bool has_speeds_{false};
+  double gps_lat_deg_{0.0};
+  double gps_lon_deg_{0.0};
+  double gps_speed_mps_{0.0};
+  bool has_gps_{false};
 
   struct FsAiApiVtable;
   std::unique_ptr<FsAiApiVtable> api_;

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -6,12 +6,15 @@
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
+#include <deque>
 #include <memory>
 #include <optional>
+#include <random>
 #include <string>
 #include <vector>
 
 #include <SDL.h>
+#include <yaml-cpp/yaml.h>
 
 #include "Graphics.h"
 #include "budget.h"
@@ -41,6 +44,7 @@ constexpr double kCommandStaleSeconds = 0.1;
 constexpr double kBaseLatitudeDeg = 37.4275;
 constexpr double kBaseLongitudeDeg = -122.1697;
 constexpr double kMetersPerDegreeLat = 111111.0;
+constexpr const char* kDefaultSensorConfig = "../configs/sim/sensors.yaml";
 
 inline double metersToLatitude(double north_meters) {
   return kBaseLatitudeDeg + north_meters / kMetersPerDegreeLat;
@@ -51,6 +55,155 @@ inline double metersToLongitude(double east_meters) {
   const double meters_per_degree_lon =
       kMetersPerDegreeLat * std::max(0.1, cos_lat);
   return kBaseLongitudeDeg + east_meters / meters_per_degree_lon;
+}
+
+struct ChannelNoiseConfig {
+  double noise_std{0.0};
+  double latency_s{0.0};
+};
+
+struct TorqueNoiseConfig {
+  double front_noise_std_nm{0.0};
+  double rear_noise_std_nm{0.0};
+  double latency_s{0.0};
+};
+
+struct ImuNoiseConfig {
+  double accel_longitudinal_std{0.0};
+  double accel_lateral_std{0.0};
+  double yaw_rate_std_degps{0.0};
+  double latency_s{0.0};
+};
+
+struct GpsNoiseConfig {
+  double lat_std_deg{0.0};
+  double lon_std_deg{0.0};
+  double speed_std_mps{0.0};
+  double latency_s{0.0};
+};
+
+struct SensorNoiseConfig {
+  uint32_t seed{1337u};
+  ChannelNoiseConfig steering_deg{};
+  ChannelNoiseConfig wheel_rpm{};
+  TorqueNoiseConfig drive_torque{};
+  ChannelNoiseConfig brake_pct{};
+  ChannelNoiseConfig speed_kph{};
+  ImuNoiseConfig imu{};
+  GpsNoiseConfig gps{};
+};
+
+template <typename T>
+class SensorDelayLine {
+ public:
+  void set_latency(uint64_t latency_ns) { latency_ns_ = latency_ns; }
+
+  void push(uint64_t timestamp_ns, const T& value) {
+    queue_.emplace_back(timestamp_ns, value);
+  }
+
+  std::optional<T> poll(uint64_t now_ns) {
+    if (latency_ns_ == 0) {
+      if (!queue_.empty()) {
+        last_value_ = queue_.back().second;
+        queue_.clear();
+      }
+      return last_value_;
+    }
+    while (!queue_.empty()) {
+      const auto& front = queue_.front();
+      if (front.first + latency_ns_ <= now_ns) {
+        last_value_ = front.second;
+        queue_.pop_front();
+      } else {
+        break;
+      }
+    }
+    return last_value_;
+  }
+
+ private:
+  uint64_t latency_ns_{0};
+  std::deque<std::pair<uint64_t, T>> queue_{};
+  std::optional<T> last_value_{};
+};
+
+struct TorqueSample {
+  float front_nm{0.0f};
+  float rear_nm{0.0f};
+};
+
+struct BrakeSample {
+  float front_pct{0.0f};
+  float rear_pct{0.0f};
+  float front_req_pct{0.0f};
+  float rear_req_pct{0.0f};
+};
+
+struct GpsSample {
+  double lat_deg{0.0};
+  double lon_deg{0.0};
+  double speed_mps{0.0};
+};
+
+SensorNoiseConfig LoadSensorNoiseConfig(const std::string& path) {
+  SensorNoiseConfig cfg;
+  try {
+    YAML::Node root = YAML::LoadFile(path);
+    if (auto seed = root["seed"]) {
+      cfg.seed = seed.as<uint32_t>(cfg.seed);
+    }
+    if (auto steering = root["steering"]) {
+      cfg.steering_deg.noise_std = steering["noise_std_deg"].as<double>(cfg.steering_deg.noise_std);
+      if (auto latency = steering["latency_ms"]) {
+        cfg.steering_deg.latency_s = latency.as<double>(0.0) * 1e-3;
+      }
+    }
+    if (auto wheel = root["wheel_speed"]) {
+      cfg.wheel_rpm.noise_std = wheel["noise_std_rpm"].as<double>(cfg.wheel_rpm.noise_std);
+      if (auto latency = wheel["latency_ms"]) {
+        cfg.wheel_rpm.latency_s = latency.as<double>(0.0) * 1e-3;
+      }
+    }
+    if (auto torque = root["drive_torque"]) {
+      cfg.drive_torque.front_noise_std_nm = torque["front_noise_std_nm"].as<double>(cfg.drive_torque.front_noise_std_nm);
+      cfg.drive_torque.rear_noise_std_nm = torque["rear_noise_std_nm"].as<double>(cfg.drive_torque.rear_noise_std_nm);
+      if (auto latency = torque["latency_ms"]) {
+        cfg.drive_torque.latency_s = latency.as<double>(0.0) * 1e-3;
+      }
+    }
+    if (auto brake = root["brake"]) {
+      cfg.brake_pct.noise_std = brake["noise_std_pct"].as<double>(cfg.brake_pct.noise_std);
+      if (auto latency = brake["latency_ms"]) {
+        cfg.brake_pct.latency_s = latency.as<double>(0.0) * 1e-3;
+      }
+    }
+    if (auto speed = root["speed"]) {
+      cfg.speed_kph.noise_std = speed["noise_std_kph"].as<double>(cfg.speed_kph.noise_std);
+      if (auto latency = speed["latency_ms"]) {
+        cfg.speed_kph.latency_s = latency.as<double>(0.0) * 1e-3;
+      }
+    }
+    if (auto imu = root["imu"]) {
+      cfg.imu.accel_longitudinal_std = imu["noise_std_ax"].as<double>(cfg.imu.accel_longitudinal_std);
+      cfg.imu.accel_lateral_std = imu["noise_std_ay"].as<double>(cfg.imu.accel_lateral_std);
+      cfg.imu.yaw_rate_std_degps = imu["noise_std_yaw_degps"].as<double>(cfg.imu.yaw_rate_std_degps);
+      if (auto latency = imu["latency_ms"]) {
+        cfg.imu.latency_s = latency.as<double>(0.0) * 1e-3;
+      }
+    }
+    if (auto gps = root["gps"]) {
+      cfg.gps.lat_std_deg = gps["noise_std_lat_deg"].as<double>(cfg.gps.lat_std_deg);
+      cfg.gps.lon_std_deg = gps["noise_std_lon_deg"].as<double>(cfg.gps.lon_std_deg);
+      cfg.gps.speed_std_mps = gps["noise_std_speed_mps"].as<double>(cfg.gps.speed_std_mps);
+      if (auto latency = gps["latency_ms"]) {
+        cfg.gps.latency_s = latency.as<double>(0.0) * 1e-3;
+      }
+    }
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "Failed to load sensor config '%s': %s\n", path.c_str(), e.what());
+  }
+  return cfg;
 }
 }  // namespace
 
@@ -73,6 +226,7 @@ int main(int argc, char* argv[]) {
   bool can_iface_overridden = false;
   uint16_t command_port = kDefaultCommandPort;
   uint16_t telemetry_port = kDefaultTelemetryPort;
+  std::string sensor_config_path = kDefaultSensorConfig;
 
   for (int i = 1; i < argc; ++i) {
     const std::string arg = argv[i];
@@ -87,10 +241,12 @@ int main(int argc, char* argv[]) {
       command_port = parse_port(argv[++i], command_port);
     } else if (arg == "--state-port" && i + 1 < argc) {
       telemetry_port = parse_port(argv[++i], telemetry_port);
+    } else if (arg == "--sensor-config" && i + 1 < argc) {
+      sensor_config_path = argv[++i];
     } else if (arg == "--help") {
       std::printf(
           "Usage: fsai_run [--dt seconds] [--can-if iface|udp:port] [--cmd-port p] "
-          "[--state-port p]\n");
+          "[--state-port p] [--sensor-config path]\n");
       return EXIT_SUCCESS;
     } else if (i == 1 && argc == 2) {
       dt = std::atof(arg.c_str());
@@ -118,6 +274,16 @@ int main(int argc, char* argv[]) {
       dt, mode.c_str(), can_iface.c_str(), can_is_udp ? "udp" : "socketcan",
       command_port, telemetry_port);
 
+  SensorNoiseConfig sensor_cfg = LoadSensorNoiseConfig(sensor_config_path);
+  std::mt19937 noise_rng(sensor_cfg.seed);
+  auto sample_noise = [&noise_rng](double stddev) {
+    if (stddev <= 0.0) {
+      return 0.0;
+    }
+    std::normal_distribution<double> dist(0.0, stddev);
+    return dist(noise_rng);
+  };
+
   fsai_clock_config clock_cfg{};
   clock_cfg.mode = FSAI_CLOCK_MODE_SIMULATED;
   clock_cfg.start_time_ns = 0;
@@ -127,6 +293,37 @@ int main(int argc, char* argv[]) {
   const double step_seconds = fsai_clock_to_seconds(step_ns);
   const uint64_t ai2vcu_period_ns = fsai_clock_from_seconds(0.01);
   uint64_t last_ai2vcu_tx_ns = 0;
+
+  SensorDelayLine<float> steer_delay;
+  SensorDelayLine<std::array<float, 4>> wheel_delay;
+  SensorDelayLine<TorqueSample> torque_delay;
+  SensorDelayLine<BrakeSample> brake_delay;
+  SensorDelayLine<float> speed_delay;
+  SensorDelayLine<fsai::sim::svcu::dbc::Ai2LogDynamics2> imu_delay;
+  SensorDelayLine<GpsSample> gps_delay;
+
+  steer_delay.set_latency(fsai_clock_from_seconds(sensor_cfg.steering_deg.latency_s));
+  wheel_delay.set_latency(fsai_clock_from_seconds(sensor_cfg.wheel_rpm.latency_s));
+  torque_delay.set_latency(fsai_clock_from_seconds(sensor_cfg.drive_torque.latency_s));
+  brake_delay.set_latency(fsai_clock_from_seconds(sensor_cfg.brake_pct.latency_s));
+  speed_delay.set_latency(fsai_clock_from_seconds(sensor_cfg.speed_kph.latency_s));
+  imu_delay.set_latency(fsai_clock_from_seconds(sensor_cfg.imu.latency_s));
+  gps_delay.set_latency(fsai_clock_from_seconds(sensor_cfg.gps.latency_s));
+
+  float steer_meas_deg = 0.0f;
+  bool has_steer_meas = false;
+  std::array<float, 4> wheel_meas_rpm{0.0f, 0.0f, 0.0f, 0.0f};
+  bool has_wheel_meas = false;
+  TorqueSample torque_meas{};
+  bool has_torque_meas = false;
+  BrakeSample brake_meas{};
+  bool has_brake_meas = false;
+  float speed_meas_kph = 0.0f;
+  bool has_speed_meas = false;
+  fsai::sim::svcu::dbc::Ai2LogDynamics2 imu_meas{};
+  bool has_imu_meas = false;
+  GpsSample gps_meas{};
+  bool has_gps_meas = false;
 
   fsai_budget_init();
   fsai_budget_configure(FSAI_BUDGET_SUBSYSTEM_SIMULATION, "Simulation Renderer",
@@ -175,6 +372,8 @@ int main(int argc, char* argv[]) {
   bool running = true;
   size_t frame_counter = 0;
 
+  const VehicleParam& vehicle_param = world.model().param();
+
   fsai::control::runtime::CanIface::Config can_cfg{};
   can_cfg.endpoint = can_iface;
   can_cfg.enable_loopback = true;
@@ -183,6 +382,7 @@ int main(int argc, char* argv[]) {
   if (can_cfg.mode == fsai::control::runtime::CanIface::Mode::kFsAiApi) {
     can_cfg.enable_loopback = false;
   }
+  can_cfg.wheel_radius_m = vehicle_param.tire.radius;
 
   fsai::control::runtime::CanIface can_interface;
   if (!can_interface.Initialize(can_cfg)) {
@@ -214,7 +414,6 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  const VehicleParam& vehicle_param = world.model().param();
   const int front_motor_count = std::max(0, vehicle_param.powertrain.front_motor_count);
   const int rear_motor_count = std::max(0, vehicle_param.powertrain.rear_motor_count);
   const int total_motors = std::max(1, front_motor_count + rear_motor_count);
@@ -248,6 +447,9 @@ int main(int argc, char* argv[]) {
   adapter_cfg.max_speed_kph =
       static_cast<float>(vehicle_param.input_ranges.vel.max * 3.6);
   fsai::control::runtime::Ai2VcuAdapter ai2vcu_adapter(adapter_cfg);
+
+  fsai::control::runtime::Ai2VcuCommandSet last_ai2vcu_commands{};
+  bool has_last_ai_command = false;
 
   std::optional<fsai::sim::svcu::CommandPacket> latest_command;
   const uint64_t stale_threshold_ns =
@@ -352,6 +554,8 @@ int main(int argc, char* argv[]) {
           static_cast<uint8_t>(std::clamp(world.completedLaps(), 0, 15)));
       if (can_interface.Send(command_frames)) {
         last_ai2vcu_tx_ns = now_ns;
+        last_ai2vcu_commands = command_frames;
+        has_last_ai_command = true;
       }
     }
 
@@ -378,6 +582,200 @@ int main(int argc, char* argv[]) {
                                brake_status.front_force;
     const double rear_force = pt_status.rear_drive_force - pt_status.rear_regen_force -
                               brake_status.rear_force;
+
+    const double vehicle_speed_mps = std::sqrt(
+        vehicle_state.velocity.x() * vehicle_state.velocity.x() +
+        vehicle_state.velocity.y() * vehicle_state.velocity.y());
+    const float actual_speed_kph = static_cast<float>(vehicle_speed_mps * 3.6);
+    const float actual_steer_deg = static_cast<float>(wheel_info.steering *
+        fsai::sim::svcu::dbc::kRadToDeg);
+
+    steer_delay.push(now_ns, static_cast<float>(actual_steer_deg +
+                                                sample_noise(sensor_cfg.steering_deg.noise_std)));
+    if (auto sample = steer_delay.poll(now_ns)) {
+      steer_meas_deg = *sample;
+      has_steer_meas = true;
+    }
+
+    std::array<float, 4> wheel_rpm_sample{wheel_info.lf_speed, wheel_info.rf_speed,
+                                          wheel_info.lb_speed, wheel_info.rb_speed};
+    for (float& rpm : wheel_rpm_sample) {
+      rpm = static_cast<float>(rpm + sample_noise(sensor_cfg.wheel_rpm.noise_std));
+      if (!std::isfinite(rpm) || rpm < 0.0f) {
+        rpm = 0.0f;
+      }
+    }
+    wheel_delay.push(now_ns, wheel_rpm_sample);
+    if (auto sample = wheel_delay.poll(now_ns)) {
+      wheel_meas_rpm = *sample;
+      has_wheel_meas = true;
+    }
+
+    TorqueSample torque_sample{};
+    torque_sample.front_nm = static_cast<float>((pt_status.front_drive_force - pt_status.front_regen_force) *
+                                               wheel_radius +
+                                               sample_noise(sensor_cfg.drive_torque.front_noise_std_nm));
+    torque_sample.rear_nm = static_cast<float>((pt_status.rear_drive_force - pt_status.rear_regen_force) *
+                                              wheel_radius +
+                                              sample_noise(sensor_cfg.drive_torque.rear_noise_std_nm));
+    torque_delay.push(now_ns, torque_sample);
+    if (auto sample = torque_delay.poll(now_ns)) {
+      torque_meas = *sample;
+      has_torque_meas = true;
+    }
+
+    const double max_brake_force = std::max(1.0, model.param().brakes.max_force);
+    const double front_max_force = std::max(1e-3, max_brake_force * adapter_cfg.brake_front_bias);
+    const double rear_max_force = std::max(1e-3, max_brake_force * adapter_cfg.brake_rear_bias);
+    BrakeSample brake_sample{};
+    const double front_pct_raw = (std::max(0.0, brake_status.front_force) / front_max_force) * 100.0;
+    const double rear_pct_raw = (std::max(0.0, brake_status.rear_force) / rear_max_force) * 100.0;
+    brake_sample.front_pct = static_cast<float>(std::clamp(front_pct_raw +
+                                           sample_noise(sensor_cfg.brake_pct.noise_std), 0.0, 100.0));
+    brake_sample.rear_pct = static_cast<float>(std::clamp(rear_pct_raw +
+                                          sample_noise(sensor_cfg.brake_pct.noise_std), 0.0, 100.0));
+    brake_sample.front_req_pct = has_last_ai_command ? last_ai2vcu_commands.brake.front_pct : 0.0f;
+    brake_sample.rear_req_pct = has_last_ai_command ? last_ai2vcu_commands.brake.rear_pct : 0.0f;
+    brake_delay.push(now_ns, brake_sample);
+    if (auto sample = brake_delay.poll(now_ns)) {
+      brake_meas = *sample;
+      has_brake_meas = true;
+    }
+
+    speed_delay.push(now_ns, static_cast<float>(std::max(0.0, actual_speed_kph +
+                                     sample_noise(sensor_cfg.speed_kph.noise_std))));
+    if (auto sample = speed_delay.poll(now_ns)) {
+      speed_meas_kph = *sample;
+      has_speed_meas = true;
+    }
+
+    fsai::sim::svcu::dbc::Ai2LogDynamics2 imu_sample{};
+    imu_sample.accel_longitudinal_mps2 = static_cast<float>(
+        vehicle_state.acceleration.x() + sample_noise(sensor_cfg.imu.accel_longitudinal_std));
+    imu_sample.accel_lateral_mps2 = static_cast<float>(
+        vehicle_state.acceleration.y() + sample_noise(sensor_cfg.imu.accel_lateral_std));
+    imu_sample.yaw_rate_degps = static_cast<float>(
+        vehicle_state.rotation.z() * fsai::sim::svcu::dbc::kRadToDeg +
+        sample_noise(sensor_cfg.imu.yaw_rate_std_degps));
+    imu_delay.push(now_ns, imu_sample);
+    if (auto sample = imu_delay.poll(now_ns)) {
+      imu_meas = *sample;
+      has_imu_meas = true;
+    }
+
+    GpsSample gps_sample{};
+    gps_sample.lat_deg = metersToLatitude(vehicle_state.position.y()) +
+                         sample_noise(sensor_cfg.gps.lat_std_deg);
+    gps_sample.lon_deg = metersToLongitude(vehicle_state.position.x()) +
+                         sample_noise(sensor_cfg.gps.lon_std_deg);
+    gps_sample.speed_mps = std::max(0.0, vehicle_speed_mps +
+                                    sample_noise(sensor_cfg.gps.speed_std_mps));
+    gps_delay.push(now_ns, gps_sample);
+    if (auto sample = gps_delay.poll(now_ns)) {
+      gps_meas = *sample;
+      has_gps_meas = true;
+    }
+
+    const float steer_for_msg = has_steer_meas ? steer_meas_deg : 0.0f;
+    const std::array<float, 4> wheel_for_msg = has_wheel_meas ? wheel_meas_rpm
+                                                              : std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f};
+    const TorqueSample torque_for_msg = has_torque_meas ? torque_meas : TorqueSample{};
+    const BrakeSample brake_for_msg = has_brake_meas ? brake_meas : BrakeSample{};
+    const float speed_for_msg_kph = has_speed_meas ? speed_meas_kph : actual_speed_kph;
+
+    fsai::sim::svcu::dbc::Vcu2AiStatus status_msg{};
+    status_msg.handshake = true;
+    status_msg.as_switch_on = true;
+    status_msg.ts_switch_on = true;
+    status_msg.go_signal = true;
+    status_msg.as_state = world.useRacingAlgorithm
+                              ? fsai::sim::svcu::dbc::AsState::kDriving
+                              : fsai::sim::svcu::dbc::AsState::kReady;
+    status_msg.steering_status = fsai::sim::svcu::dbc::SteeringStatus::kActive;
+
+    fsai::sim::svcu::dbc::Vcu2AiSteer steer_msg{};
+    steer_msg.angle_deg = steer_for_msg;
+    steer_msg.angle_max_deg = fsai::sim::svcu::dbc::kMaxSteerDeg;
+    steer_msg.angle_request_deg = has_last_ai_command
+                                      ? last_ai2vcu_commands.steer.steer_deg
+                                      : steer_for_msg;
+
+    fsai::sim::svcu::dbc::Vcu2AiDrive front_drive_msg{};
+    front_drive_msg.axle_trq_nm = torque_for_msg.front_nm;
+    front_drive_msg.axle_trq_max_nm = fsai::sim::svcu::dbc::kMaxAxleTorqueNm;
+    front_drive_msg.axle_trq_request_nm = has_last_ai_command
+        ? last_ai2vcu_commands.front_drive.axle_torque_request_nm
+        : std::max(0.0f, torque_for_msg.front_nm);
+
+    fsai::sim::svcu::dbc::Vcu2AiDrive rear_drive_msg{};
+    rear_drive_msg.axle_trq_nm = torque_for_msg.rear_nm;
+    rear_drive_msg.axle_trq_max_nm = fsai::sim::svcu::dbc::kMaxAxleTorqueNm;
+    rear_drive_msg.axle_trq_request_nm = has_last_ai_command
+        ? last_ai2vcu_commands.rear_drive.axle_torque_request_nm
+        : std::max(0.0f, torque_for_msg.rear_nm);
+
+    fsai::sim::svcu::dbc::Vcu2AiSpeeds speed_msg{};
+    for (size_t i = 0; i < wheel_for_msg.size(); ++i) {
+      speed_msg.wheel_rpm[i] = wheel_for_msg[i];
+    }
+
+    fsai::sim::svcu::dbc::Vcu2AiBrake brake_msg{};
+    brake_msg.front_pct = brake_for_msg.front_pct;
+    brake_msg.rear_pct = brake_for_msg.rear_pct;
+    brake_msg.front_req_pct = brake_for_msg.front_req_pct;
+    brake_msg.rear_req_pct = brake_for_msg.rear_req_pct;
+    brake_msg.status_brk = fsai::sim::svcu::dbc::BrakeStatus::kReady;
+    brake_msg.status_ebs = fsai::sim::svcu::dbc::EbsStatus::kArmed;
+
+    fsai::sim::svcu::dbc::Vcu2LogDynamics1 dyn_msg{};
+    dyn_msg.speed_actual_kph = speed_for_msg_kph;
+    dyn_msg.speed_target_kph = has_last_ai_command
+                                   ? last_ai2vcu_commands.status.veh_speed_demand_kph
+                                   : speed_for_msg_kph;
+    dyn_msg.steer_actual_deg = steer_for_msg;
+    dyn_msg.steer_target_deg = has_last_ai_command
+                                   ? last_ai2vcu_commands.steer.steer_deg
+                                   : steer_for_msg;
+    const float brake_target_pct = has_last_ai_command
+        ? (last_ai2vcu_commands.brake.front_pct + last_ai2vcu_commands.brake.rear_pct) * 0.5f
+        : (brake_for_msg.front_req_pct + brake_for_msg.rear_req_pct) * 0.5f;
+    dyn_msg.brake_actual_pct = (brake_for_msg.front_pct + brake_for_msg.rear_pct) * 0.5f;
+    dyn_msg.brake_target_pct = brake_target_pct;
+    const double total_req_torque_nm = has_last_ai_command
+        ? static_cast<double>(last_ai2vcu_commands.front_drive.axle_torque_request_nm +
+                              last_ai2vcu_commands.rear_drive.axle_torque_request_nm)
+        : 0.0;
+    const double total_actual_torque_nm = std::abs(static_cast<double>(torque_for_msg.front_nm)) +
+                                          std::abs(static_cast<double>(torque_for_msg.rear_nm));
+    auto torque_to_pct = [](double torque_nm) {
+      return static_cast<float>(std::clamp(torque_nm /
+                                           (2.0 * fsai::sim::svcu::dbc::kMaxAxleTorqueNm) * 100.0,
+                                           0.0, 255.0));
+    };
+    dyn_msg.drive_trq_actual_pct = torque_to_pct(total_actual_torque_nm);
+    dyn_msg.drive_trq_target_pct = torque_to_pct(total_req_torque_nm);
+
+    auto send_sim_frame = [&](const can_frame& frame) {
+      if (!can_interface.SendSimulationFrame(frame)) {
+        std::fprintf(stderr, "Failed to send simulation CAN frame id=%u\n", frame.can_id);
+      }
+    };
+
+    send_sim_frame(fsai::sim::svcu::dbc::encode_vcu2ai_status(status_msg));
+    send_sim_frame(fsai::sim::svcu::dbc::encode_vcu2ai_steer(steer_msg));
+    send_sim_frame(fsai::sim::svcu::dbc::encode_vcu2ai_drive_front(front_drive_msg));
+    send_sim_frame(fsai::sim::svcu::dbc::encode_vcu2ai_drive_rear(rear_drive_msg));
+    send_sim_frame(fsai::sim::svcu::dbc::encode_vcu2ai_speeds(speed_msg));
+    send_sim_frame(fsai::sim::svcu::dbc::encode_vcu2ai_brake(brake_msg));
+    send_sim_frame(fsai::sim::svcu::dbc::encode_vcu2log_dynamics1(dyn_msg));
+    send_sim_frame(fsai::sim::svcu::dbc::encode_ai2log_dynamics2(imu_meas));
+
+    if (has_gps_meas) {
+      can_interface.SetSimulationGpsSample(gps_meas.lat_deg, gps_meas.lon_deg,
+                                          gps_meas.speed_mps);
+    }
+
+    can_interface.Poll(now_ns);
 
     fsai::sim::svcu::TelemetryPacket telemetry{};
     telemetry.t_ns = now_ns;

--- a/sim/svcu/adsdv_dbc.cpp
+++ b/sim/svcu/adsdv_dbc.cpp
@@ -207,6 +207,16 @@ bool decode_vcu2ai_brake(const can_frame& frame, Vcu2AiBrake& out) {
   return true;
 }
 
+bool decode_vcu2ai_speeds(const can_frame& frame, Vcu2AiSpeeds& out) {
+  if (frame.can_id != kMsgIdVcu2AiSpeeds || frame.can_dlc < 8) {
+    return false;
+  }
+  for (int i = 0; i < 4; ++i) {
+    out.wheel_rpm[i] = static_cast<float>(read_u16_le(frame.data + (i * 2)));
+  }
+  return true;
+}
+
 bool decode_vcu2log_dynamics1(const can_frame& frame, Vcu2LogDynamics1& out) {
   if (frame.can_id != kMsgIdVcu2LogDynamics1 || frame.can_dlc < 8) {
     return false;

--- a/sim/svcu/adsdv_dbc.hpp
+++ b/sim/svcu/adsdv_dbc.hpp
@@ -161,6 +161,7 @@ bool decode_vcu2ai_steer(const can_frame& frame, Vcu2AiSteer& out);
 bool decode_vcu2ai_drive_front(const can_frame& frame, Vcu2AiDrive& out);
 bool decode_vcu2ai_drive_rear(const can_frame& frame, Vcu2AiDrive& out);
 bool decode_vcu2ai_brake(const can_frame& frame, Vcu2AiBrake& out);
+bool decode_vcu2ai_speeds(const can_frame& frame, Vcu2AiSpeeds& out);
 bool decode_vcu2log_dynamics1(const can_frame& frame, Vcu2LogDynamics1& out);
 bool decode_ai2log_dynamics2(const can_frame& frame, Ai2LogDynamics2& out);
 


### PR DESCRIPTION
## Summary
- compute simulated steering, torque, wheel-speed, brake and status signals each physics tick and publish them on the VCU→AI CAN bus
- extend the CAN runtime to accept simulation feedback frames, inject GPS samples, and derive vehicle speed from wheel RPM when available
- add a YAML-configured sensor noise/latency model for CAN-fed sensors to support estimator regression scenarios

## Testing
- cmake -S . -B build *(fails: Eigen3 package is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb4fe50b1c8324b113b3b85dc335e3