### PR TITLE
Implement AI-VCU runtime safety state machine

### DIFF
--- a/control/runtime_cpp/ai2vcu_adapter.cpp
+++ b/control/runtime_cpp/ai2vcu_adapter.cpp
@@ -114,6 +114,12 @@ void Ai2VcuAdapter::UpdateStatusFlags(
 
 Ai2VcuCommandSet Ai2VcuAdapter::Adapt(
     const fsai::types::ControlCmd& cmd,
+    const fsai::sim::svcu::dbc::Vcu2AiStatus& feedback) {
+  return Adapt(cmd, feedback, AdapterTelemetry{});
+}
+
+Ai2VcuCommandSet Ai2VcuAdapter::Adapt(
+    const fsai::types::ControlCmd& cmd,
     const fsai::sim::svcu::dbc::Vcu2AiStatus& feedback,
     const AdapterTelemetry& telemetry) {
   ToggleHandshake();

--- a/control/runtime_cpp/ai2vcu_adapter.cpp
+++ b/control/runtime_cpp/ai2vcu_adapter.cpp
@@ -18,53 +18,154 @@ Ai2VcuAdapter::Ai2VcuAdapter(const Ai2VcuAdapterConfig& config)
   config_.brake_front_bias = std::clamp(config_.brake_front_bias / brake_sum, 0.0f, 1.0f);
   config_.brake_rear_bias = std::clamp(1.0f - config_.brake_front_bias, 0.0f, 1.0f);
 
-  status_.handshake = true;
-  status_.mission_status = fsai::sim::svcu::dbc::MissionStatus::kSelected;
-  status_.direction_request = fsai::sim::svcu::dbc::DirectionRequest::kForward;
+  status_.handshake = handshake_level_;
+  status_.mission_status = fsai::sim::svcu::dbc::MissionStatus::kNotSelected;
+  status_.direction_request = fsai::sim::svcu::dbc::DirectionRequest::kNeutral;
   status_.veh_speed_actual_kph = 0.0f;
   status_.veh_speed_demand_kph = 0.0f;
 }
 
-Ai2VcuCommandSet Ai2VcuAdapter::Adapt(const fsai::types::ControlCmd& cmd,
-                                      float measured_speed_mps,
-                                      bool mission_running,
-                                      uint8_t lap_counter) {
-  Ai2VcuCommandSet out{};
+void Ai2VcuAdapter::ToggleHandshake() {
+  handshake_level_ = !handshake_level_;
+  status_.handshake = handshake_level_;
+}
 
-  const float throttle = std::clamp(cmd.throttle, 0.0f, 1.0f);
-  const float brake = std::clamp(cmd.brake, 0.0f, 1.0f);
+void Ai2VcuAdapter::UpdateTelemetry(const AdapterTelemetry& telemetry) {
+  status_.veh_speed_actual_kph =
+      std::clamp(telemetry.measured_speed_mps * 3.6f, 0.0f, 255.0f);
+  if (telemetry.lap_counter.has_value()) {
+    status_.lap_counter = static_cast<uint8_t>(*telemetry.lap_counter & 0x0Fu);
+  }
+  if (telemetry.cones_count_actual.has_value()) {
+    status_.cones_count_actual = *telemetry.cones_count_actual;
+  }
+  if (telemetry.cones_count_all.has_value()) {
+    status_.cones_count_all = *telemetry.cones_count_all;
+  }
+}
+
+bool Ai2VcuAdapter::ShouldEnterSafeStop(
+    const fsai::sim::svcu::dbc::Vcu2AiStatus& feedback) const {
+  if (feedback.shutdown_request) {
+    return true;
+  }
+  if (feedback.as_state == fsai::sim::svcu::dbc::AsState::kEmergencyBrake ||
+      feedback.as_state == fsai::sim::svcu::dbc::AsState::kFinished) {
+    return true;
+  }
+  return feedback.fault || feedback.ebs_fault || feedback.brake_plausibility_fault ||
+         feedback.bms_fault || feedback.autonomous_braking_fault ||
+         feedback.mission_status_fault || feedback.hvil_open_fault ||
+         feedback.hvil_short_fault || feedback.ai_comms_lost ||
+         feedback.ai_estop_request;
+}
+
+void Ai2VcuAdapter::UpdateState(const fsai::sim::svcu::dbc::Vcu2AiStatus& feedback) {
+  if (state_ == State::kSafeStop) {
+    return;
+  }
+  if (ShouldEnterSafeStop(feedback)) {
+    state_ = State::kSafeStop;
+    return;
+  }
+
+  switch (feedback.as_state) {
+    case fsai::sim::svcu::dbc::AsState::kDriving:
+      state_ = feedback.go_signal ? State::kRunning : State::kArmed;
+      break;
+    case fsai::sim::svcu::dbc::AsState::kReady:
+      state_ = feedback.go_signal ? State::kRunning : State::kArmed;
+      break;
+    case fsai::sim::svcu::dbc::AsState::kOff:
+    case fsai::sim::svcu::dbc::AsState::kR2d:
+      state_ = State::kIdle;
+      break;
+    default:
+      state_ = State::kIdle;
+      break;
+  }
+}
+
+void Ai2VcuAdapter::UpdateStatusFlags(
+    const fsai::sim::svcu::dbc::Vcu2AiStatus& feedback,
+    bool allow_motion) {
+  switch (state_) {
+    case State::kIdle:
+      status_.mission_status = fsai::sim::svcu::dbc::MissionStatus::kNotSelected;
+      break;
+    case State::kArmed:
+      status_.mission_status = fsai::sim::svcu::dbc::MissionStatus::kSelected;
+      break;
+    case State::kRunning:
+      status_.mission_status = allow_motion
+                                   ? fsai::sim::svcu::dbc::MissionStatus::kRunning
+                                   : fsai::sim::svcu::dbc::MissionStatus::kSelected;
+      break;
+    case State::kSafeStop:
+      status_.mission_status = fsai::sim::svcu::dbc::MissionStatus::kFinished;
+      break;
+  }
+
+  status_.estop_request = !allow_motion;
+  status_.direction_request =
+      allow_motion ? fsai::sim::svcu::dbc::DirectionRequest::kForward
+                   : fsai::sim::svcu::dbc::DirectionRequest::kNeutral;
+}
+
+Ai2VcuCommandSet Ai2VcuAdapter::Adapt(
+    const fsai::types::ControlCmd& cmd,
+    const fsai::sim::svcu::dbc::Vcu2AiStatus& feedback,
+    const AdapterTelemetry& telemetry) {
+  ToggleHandshake();
+  UpdateTelemetry(telemetry);
+  UpdateState(feedback);
+
+  const bool allow_motion = state_ == State::kRunning && feedback.go_signal;
+
+  const float throttle = allow_motion ? std::clamp(cmd.throttle, 0.0f, 1.0f) : 0.0f;
+  const float brake = allow_motion ? std::clamp(cmd.brake, 0.0f, 1.0f) : 0.0f;
+
+  status_.veh_speed_demand_kph = allow_motion
+                                     ? std::clamp(config_.max_speed_kph * throttle, 0.0f, 255.0f)
+                                     : 0.0f;
+  UpdateStatusFlags(feedback, allow_motion);
+
+  Ai2VcuCommandSet out{};
   out.throttle_clamped = throttle;
   out.brake_clamped = brake;
 
-  status_.mission_status = mission_running ? fsai::sim::svcu::dbc::MissionStatus::kRunning
-                                           : fsai::sim::svcu::dbc::MissionStatus::kSelected;
-  status_.estop_request = false;
-  status_.lap_counter = static_cast<uint8_t>(lap_counter & 0x0Fu);
-  status_.veh_speed_actual_kph = std::clamp(measured_speed_mps * 3.6f, 0.0f, 255.0f);
-  status_.veh_speed_demand_kph = std::clamp(config_.max_speed_kph * throttle, 0.0f, 255.0f);
+  if (allow_motion) {
+    out.steer.steer_deg = std::clamp(
+        cmd.steer_rad * fsai::sim::svcu::dbc::kRadToDeg,
+        -fsai::sim::svcu::dbc::kMaxSteerDeg,
+        fsai::sim::svcu::dbc::kMaxSteerDeg);
+
+    const float total_torque_nm = throttle * 2.0f * fsai::sim::svcu::dbc::kMaxAxleTorqueNm;
+    out.front_drive.axle_torque_request_nm =
+        std::clamp(total_torque_nm * config_.front_motor_weight, 0.0f,
+                   fsai::sim::svcu::dbc::kMaxAxleTorqueNm);
+    out.rear_drive.axle_torque_request_nm =
+        std::clamp(total_torque_nm * config_.rear_motor_weight, 0.0f,
+                   fsai::sim::svcu::dbc::kMaxAxleTorqueNm);
+    out.front_drive.motor_speed_max_rpm = config_.motor_speed_max_rpm;
+    out.rear_drive.motor_speed_max_rpm = config_.motor_speed_max_rpm;
+
+    const float brake_pct = brake * fsai::sim::svcu::dbc::kMaxBrakePercent;
+    out.brake.front_pct = std::clamp(brake_pct * config_.brake_front_bias, 0.0f,
+                                     fsai::sim::svcu::dbc::kMaxBrakePercent);
+    out.brake.rear_pct = std::clamp(brake_pct * config_.brake_rear_bias, 0.0f,
+                                    fsai::sim::svcu::dbc::kMaxBrakePercent);
+  } else {
+    out.steer.steer_deg = 0.0f;
+    out.front_drive.axle_torque_request_nm = 0.0f;
+    out.rear_drive.axle_torque_request_nm = 0.0f;
+    out.front_drive.motor_speed_max_rpm = 0.0f;
+    out.rear_drive.motor_speed_max_rpm = 0.0f;
+    out.brake.front_pct = 0.0f;
+    out.brake.rear_pct = 0.0f;
+  }
+
   out.status = status_;
-
-  const float steer_deg = std::clamp(cmd.steer_rad * fsai::sim::svcu::dbc::kRadToDeg,
-                                     -fsai::sim::svcu::dbc::kMaxSteerDeg,
-                                     fsai::sim::svcu::dbc::kMaxSteerDeg);
-  out.steer.steer_deg = steer_deg;
-
-  const float total_torque_nm = throttle * 2.0f * fsai::sim::svcu::dbc::kMaxAxleTorqueNm;
-  out.front_drive.axle_torque_request_nm =
-      std::clamp(total_torque_nm * config_.front_motor_weight, 0.0f,
-                 fsai::sim::svcu::dbc::kMaxAxleTorqueNm);
-  out.rear_drive.axle_torque_request_nm =
-      std::clamp(total_torque_nm * config_.rear_motor_weight, 0.0f,
-                 fsai::sim::svcu::dbc::kMaxAxleTorqueNm);
-  out.front_drive.motor_speed_max_rpm = config_.motor_speed_max_rpm;
-  out.rear_drive.motor_speed_max_rpm = config_.motor_speed_max_rpm;
-
-  const float brake_pct = brake * fsai::sim::svcu::dbc::kMaxBrakePercent;
-  out.brake.front_pct = std::clamp(brake_pct * config_.brake_front_bias, 0.0f,
-                                   fsai::sim::svcu::dbc::kMaxBrakePercent);
-  out.brake.rear_pct = std::clamp(brake_pct * config_.brake_rear_bias, 0.0f,
-                                  fsai::sim::svcu::dbc::kMaxBrakePercent);
-
   return out;
 }
 

--- a/control/runtime_cpp/ai2vcu_adapter.hpp
+++ b/control/runtime_cpp/ai2vcu_adapter.hpp
@@ -39,8 +39,10 @@ class Ai2VcuAdapter {
   explicit Ai2VcuAdapter(const Ai2VcuAdapterConfig& config);
 
   Ai2VcuCommandSet Adapt(const fsai::types::ControlCmd& cmd,
+                         const fsai::sim::svcu::dbc::Vcu2AiStatus& feedback);
+  Ai2VcuCommandSet Adapt(const fsai::types::ControlCmd& cmd,
                          const fsai::sim::svcu::dbc::Vcu2AiStatus& feedback,
-                         const AdapterTelemetry& telemetry = AdapterTelemetry{});
+                         const AdapterTelemetry& telemetry);
 
  private:
   enum class State {


### PR DESCRIPTION
## Summary
- add a finite-state machine in the AI→VCU adapter that gates mission status, direction, estop, and actuator outputs based on VCU feedback
- toggle the handshake bit each tick while tracking lap and cone counters where available
- update simulator runtime and tests to pass VCU status/telemetry into the adapter

## Testing
- cmake -S . -B build *(fails: Eigen3 package not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ff99064a6483248afe3a894a5660fe