### PR TITLE
Add control telemetry panel with AI/manual command status

### DIFF
--- a/sim/app/runtime_telemetry.hpp
+++ b/sim/app/runtime_telemetry.hpp
@@ -87,6 +87,13 @@ struct RuntimeTelemetry {
     float applied_throttle{0.0f};
     float applied_brake{0.0f};
     float applied_steer_rad{0.0f};
+    float manual_throttle{0.0f};
+    float manual_brake{0.0f};
+    float manual_steer_rad{0.0f};
+    TimedSample<fsai::types::ControlCmd> ai_command{};
+    bool ai_command_enabled{false};
+    bool ai_command_applied{false};
+    bool fallback_to_manual{false};
     bool has_last_command{false};
     std::optional<fsai::control::runtime::Ai2VcuCommandSet> last_command{};
   } control;


### PR DESCRIPTION
## Summary
- extend the runtime control snapshot with manual inputs and the most recent AI command sample
- add an ImGui control panel reporting command magnitudes, staleness timers, and CAN acknowledgement lag indicators
- surface command fallback state when AI control is stale or unavailable

## Testing
- cmake -S FSAI_Simulation_C -B FSAI_Simulation_C/build *(fails: missing Eigen3 package)*

------
https://chatgpt.com/codex/tasks/task_e_69011a2308cc832497121e8ed01817a7