### PR TITLE
Add in-memory logging console to simulation UI

### DIFF
--- a/sim/include/logging.hpp
+++ b/sim/include/logging.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace fsai::sim::log {
+
+enum class Level {
+  kInfo,
+  kWarning,
+  kError,
+};
+
+struct Entry {
+  Level level;
+  std::string formatted;
+};
+
+// Append a message to the in-memory log buffer. Optionally mirror to stdout.
+void Log(Level level, std::string_view message, bool also_stdout = false);
+
+// Convenience helpers for common log levels.
+void LogInfo(std::string_view message);
+void LogWarning(std::string_view message);
+void LogError(std::string_view message);
+
+// Variants that also print to stdout immediately.
+void LogInfoToStdout(std::string_view message);
+
+// printf-style helpers for formatting messages.
+void Logf(Level level, const char* fmt, ...);
+void LogfToStdout(Level level, const char* fmt, ...);
+
+// Retrieve a snapshot of the buffered log entries.
+std::vector<Entry> Snapshot();
+
+// Clear all buffered log entries.
+void Clear();
+
+// Returns true if the UI should scroll to the newest entry.
+bool ConsumeScrollRequest();
+
+}  // namespace fsai::sim::log

--- a/sim/src/integration/stereo_display.cpp
+++ b/sim/src/integration/stereo_display.cpp
@@ -2,6 +2,8 @@
 
 #include <cstdio>
 
+#include "logging.hpp"
+
 namespace fsai::sim::integration {
 
 StereoDisplay::~StereoDisplay() { reset(); }
@@ -23,7 +25,8 @@ bool StereoDisplay::ensureResources(const FsaiStereoFrame& frame) {
                              height_,
                              SDL_WINDOW_SHOWN);
   if (!window_) {
-    std::fprintf(stderr, "Failed to create stereo window: %s\n", SDL_GetError());
+    fsai::sim::log::Logf(fsai::sim::log::Level::kError,
+                         "Failed to create stereo window: %s", SDL_GetError());
     reset();
     return false;
   }
@@ -32,7 +35,8 @@ bool StereoDisplay::ensureResources(const FsaiStereoFrame& frame) {
                                  SDL_RENDERER_ACCELERATED |
                                      SDL_RENDERER_PRESENTVSYNC);
   if (!renderer_) {
-    std::fprintf(stderr, "Failed to create stereo renderer: %s\n", SDL_GetError());
+    fsai::sim::log::Logf(fsai::sim::log::Level::kError,
+                         "Failed to create stereo renderer: %s", SDL_GetError());
     reset();
     return false;
   }
@@ -44,7 +48,8 @@ bool StereoDisplay::ensureResources(const FsaiStereoFrame& frame) {
                                      SDL_TEXTUREACCESS_STREAMING,
                                      width_, height_);
   if (!left_texture_ || !right_texture_) {
-    std::fprintf(stderr, "Failed to create stereo textures: %s\n", SDL_GetError());
+    fsai::sim::log::Logf(fsai::sim::log::Level::kError,
+                         "Failed to create stereo textures: %s", SDL_GetError());
     reset();
     return false;
   }

--- a/sim/src/logging.cpp
+++ b/sim/src/logging.cpp
@@ -1,0 +1,153 @@
+#include "logging.hpp"
+
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <deque>
+#include <iomanip>
+#include <ctime>
+#include <mutex>
+#include <sstream>
+#include <string>
+
+namespace fsai::sim::log {
+namespace {
+constexpr size_t kMaxEntries = 512;
+
+const char* LevelTag(Level level) {
+  switch (level) {
+    case Level::kInfo:
+      return "INFO";
+    case Level::kWarning:
+      return "WARN";
+    case Level::kError:
+      return "ERROR";
+  }
+  return "INFO";
+}
+
+struct LogState {
+  std::deque<Entry> entries;
+  bool scroll_to_bottom{false};
+  std::mutex mutex;
+};
+
+LogState& GetState() {
+  static LogState state;
+  return state;
+}
+
+std::string FormatTimestamp(const std::chrono::system_clock::time_point& tp) {
+  const auto tt = std::chrono::system_clock::to_time_t(tp);
+  std::tm tm{};
+#if defined(_WIN32)
+  localtime_s(&tm, &tt);
+#else
+  localtime_r(&tt, &tm);
+#endif
+  const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      tp.time_since_epoch()) % 1000;
+  std::ostringstream oss;
+  oss << std::put_time(&tm, "%H:%M:%S") << '.' << std::setw(3) << std::setfill('0')
+      << ms.count();
+  return oss.str();
+}
+
+std::string SanitizeMessage(std::string_view message) {
+  std::string sanitized(message);
+  while (!sanitized.empty() &&
+         (sanitized.back() == '\n' || sanitized.back() == '\r')) {
+    sanitized.pop_back();
+  }
+  return sanitized;
+}
+
+std::string FormatString(const char* fmt, va_list args) {
+  va_list copy;
+  va_copy(copy, args);
+  const int len = std::vsnprintf(nullptr, 0, fmt, copy);
+  va_end(copy);
+  if (len <= 0) {
+    return {};
+  }
+  std::string buffer(static_cast<size_t>(len) + 1, '\0');
+  std::vsnprintf(buffer.data(), buffer.size(), fmt, args);
+  buffer.resize(static_cast<size_t>(len));
+  return buffer;
+}
+
+void AppendEntry(Level level, std::string_view message, bool also_stdout) {
+  std::string sanitized = SanitizeMessage(message);
+  const auto now = std::chrono::system_clock::now();
+  const std::string timestamp = FormatTimestamp(now);
+  std::string formatted = '[' + timestamp + std::string("] [") + LevelTag(level) + "] " +
+                          sanitized;
+
+  auto& state = GetState();
+  {
+    std::scoped_lock lock(state.mutex);
+    state.entries.push_back(Entry{level, formatted});
+    if (state.entries.size() > kMaxEntries) {
+      state.entries.pop_front();
+    }
+    state.scroll_to_bottom = true;
+  }
+
+  if (also_stdout) {
+    std::fprintf(stdout, "%s\n", formatted.c_str());
+  }
+}
+
+}  // namespace
+
+void Log(Level level, std::string_view message, bool also_stdout) {
+  AppendEntry(level, message, also_stdout);
+}
+
+void LogInfo(std::string_view message) { Log(Level::kInfo, message); }
+
+void LogWarning(std::string_view message) { Log(Level::kWarning, message); }
+
+void LogError(std::string_view message) { Log(Level::kError, message); }
+
+void LogInfoToStdout(std::string_view message) {
+  Log(Level::kInfo, message, true);
+}
+
+void Logf(Level level, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  const std::string formatted = FormatString(fmt, args);
+  va_end(args);
+  AppendEntry(level, formatted, false);
+}
+
+void LogfToStdout(Level level, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  const std::string formatted = FormatString(fmt, args);
+  va_end(args);
+  AppendEntry(level, formatted, true);
+}
+
+std::vector<Entry> Snapshot() {
+  auto& state = GetState();
+  std::scoped_lock lock(state.mutex);
+  return std::vector<Entry>(state.entries.begin(), state.entries.end());
+}
+
+void Clear() {
+  auto& state = GetState();
+  std::scoped_lock lock(state.mutex);
+  state.entries.clear();
+}
+
+bool ConsumeScrollRequest() {
+  auto& state = GetState();
+  std::scoped_lock lock(state.mutex);
+  const bool should_scroll = state.scroll_to_bottom;
+  state.scroll_to_bottom = false;
+  return should_scroll;
+}
+
+}  // namespace fsai::sim::log


### PR DESCRIPTION
## Summary
- create a shared logging utility that stores recent messages and can mirror them to stdout when needed
- render the buffered messages inside a new ImGui "Simulation Log" window with clear and auto-scroll controls
- route runtime status prints through the logger so stereo display and simulation status updates surface inside the GUI

## Testing
- cmake -S . -B build *(fails: missing Eigen3 package)*

------
https://chatgpt.com/codex/tasks/task_e_69011daabb748324af7e57b55074124a