### PR TITLE
Document simulator GUI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,73 @@ This project is a simulation-based racing application that integrates various mo
 
 ## Build Instructions
 
-To build the project, follow these steps:
+### Dependencies
 
-1. Ensure you have CMake installed on your system.
-2. Navigate to the root directory of the project.
-3. Run the following commands or use the `build.sh`/`rebuild.sh` scripts:
+Install the build toolchain and runtime libraries before configuring the project:
+
+- **Common:** CMake (3.20+), a C/C++ compiler, `pkg-config`.
+- **Math/geometry:** Eigen3, CGAL (with the Qt6 viewer component).
+- **Graphics:** SDL2, OpenGL development headers.
+- **Config/data:** yaml-cpp.
+
+Ubuntu/Debian example:
+
+```sh
+sudo apt-get update
+sudo apt-get install build-essential cmake pkg-config libsdl2-dev libyaml-cpp-dev \
+     libeigen3-dev libopengl-dev libcgal-dev libcgal-qt6-dev
+```
+
+macOS (Homebrew) example:
+
+```sh
+brew install cmake sdl2 yaml-cpp eigen cgal
+```
+
+### Configure & build
+
+1. Navigate to the root directory of the project.
+2. Generate the build tree with CMake (or use the helper scripts):
 
    ```sh
+   mkdir -p build
    cd build
    cmake ..
-   make
-
+   make -j
    ```
 
-4. The CMakeLists.txt should now automatically detect architecture (only arm and not arm) and use the correct paths
+   The provided `build.sh` and `rebuild.sh` scripts wrap the same steps.
+3. `CMakeLists.txt` will automatically detect the host architecture (ARM vs. x86) and pick the correct library paths.
 
-## Running the executables
+## Runtime GUI and controls
 
-Make sure you run an executable from within the build folder so that `configDry.yaml` can be found.
+Launch the simulator GUI from the build directory so that assets such as `configDry.yaml` resolve correctly:
+
+```sh
+./fsai_run
+```
+
+The executable opens an SDL window with Dear ImGui panels:
+
+- **Simulation Stats** – vehicle pose, kinematics, axle torques, brake system, wheel RPM, accelerations, and lap timing. Click the collapsing headers to expand/collapse individual sections.
+- **Control Panel** – shows manual inputs, AI requests, applied commands, and CAN acknowledgement timers. Color highlights indicate data freshness.
+- **CAN Telemetry** – streaming feedback from the simulated VCU. Each section is collapsible; stale data is colored amber/red.
+- **Simulation Log** – the scrolling log console that previously streamed to stdout. Use the `Clear` button to flush messages, toggle `Auto-scroll` to stay at the newest entry, and scroll with the mouse wheel to review history.
+
+Keyboard and mouse interactions:
+
+- Press **`M`** to toggle between automatic (controller) and manual driving modes.
+- In manual mode use **`W`** (throttle), **`S`** (brake), and **`A` / `D`** (steering). Keep the terminal window focused for these inputs because they are read from standard input.
+- Press **`Q`** to quit the simulator.
+- Click and drag inside any panel to scroll; right-click a panel title bar to access the standard ImGui window options.
+
+When running with the S-VCU stub, the helper script wires everything together:
+
+```sh
+tools/scripts/run_sim_with_svcu.sh
+```
+
+The script prints the process IDs and then launches the GUI-enabled simulator.
 
 ## Building BoundaryEstimation.cpp
 

--- a/tools/scripts/run_sim_with_svcu.sh
+++ b/tools/scripts/run_sim_with_svcu.sh
@@ -46,6 +46,8 @@ trap 'kill 0' INT TERM
 SVCU_PID=$!
 
 echo "S-VCU started (pid=$SVCU_PID)"
+echo "Launching fsai_run with the GUI panels (Simulation Stats, Control Panel, CAN Telemetry, Simulation Log)."
+echo "Runtime logs now appear in the Simulation Log panel instead of standard output."
 
 "$FSAI_RUN" --can-if "$CAN_IFACE" --cmd-port "$CMD_PORT" --state-port "$STATE_PORT"
 


### PR DESCRIPTION
## Summary
- add platform-specific dependency setup guidance and GUI launch instructions to the README
- document keyboard shortcuts, mouse interactions, and panel behaviour for the new telemetry windows
- update the S-VCU helper script messaging to reflect that logs now appear in the GUI instead of the console

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690121a391b48324a7b1da17ccd5df5e