### PR TITLE
Make SDL simulation window resizable

### DIFF
--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -1172,6 +1172,7 @@ int main(int argc, char* argv[]) {
     SDL_Event event;
     while (SDL_PollEvent(&event)) {
       ImGui_ImplSDL2_ProcessEvent(&event);
+      Graphics_HandleWindowEvent(&graphics, &event);
       if (event.type == SDL_QUIT) {
         running = false;
       }

--- a/tools/Graphics/Graphics.c
+++ b/tools/Graphics/Graphics.c
@@ -12,7 +12,8 @@ int Graphics_Init(Graphics* g, const char* title, int width, int height) {
     }
     g->width = width;
     g->height = height;
-    g->window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_SHOWN);
+    g->window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,
+                                 SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
     if (!g->window) {
         fprintf(stderr, "SDL_CreateWindow Error: %s\n", SDL_GetError());
         SDL_Quit();
@@ -26,6 +27,36 @@ int Graphics_Init(Graphics* g, const char* title, int width, int height) {
         return -1;
     }
     return 0;
+}
+
+void Graphics_HandleWindowEvent(Graphics* g, const SDL_Event* event) {
+    if (!g || !event) {
+        return;
+    }
+    if (event->type != SDL_WINDOWEVENT) {
+        return;
+    }
+    if (event->window.windowID != SDL_GetWindowID(g->window)) {
+        return;
+    }
+    switch (event->window.event) {
+        case SDL_WINDOWEVENT_SIZE_CHANGED:
+        case SDL_WINDOWEVENT_RESIZED: {
+            int output_w = 0;
+            int output_h = 0;
+            if (SDL_GetRendererOutputSize(g->renderer, &output_w, &output_h) == 0) {
+                g->width = output_w;
+                g->height = output_h;
+            } else {
+                g->width = event->window.data1;
+                g->height = event->window.data2;
+            }
+            SDL_RenderSetViewport(g->renderer, NULL);
+            break;
+        }
+        default:
+            break;
+    }
 }
 
 // Clears the screen with a white background.

--- a/tools/Graphics/Graphics.h
+++ b/tools/Graphics/Graphics.h
@@ -33,6 +33,9 @@ void Graphics_DrawFilledCircle(Graphics* g, int centreX, int centreY, int radius
 // Presents the current frame.
 void Graphics_Present(Graphics* g);
 
+// Handles window-specific SDL events to keep renderer state synchronized.
+void Graphics_HandleWindowEvent(Graphics* g, const SDL_Event* event);
+
 // Cleans up SDL resources.
 void Graphics_Cleanup(Graphics* g);
 


### PR DESCRIPTION
## Summary
- allow the Car Simulation 2D SDL window to be resized by enabling SDL_WINDOW_RESIZABLE
- keep renderer dimensions in sync when the window is resized and update the event loop to forward resize events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69016353aab88324ac164c5a961d5848