### PR TITLE
Add stereo frame ring buffer sharing and edge preview toggle

### DIFF
--- a/vision_test/runtime_cpp/include/vision/frame_ring_buffer.hpp
+++ b/vision_test/runtime_cpp/include/vision/frame_ring_buffer.hpp
@@ -33,7 +33,9 @@ class FrameRingBuffer {
 void copyStereoFrame(const FsaiStereoFrame& source,
                      FrameRingBuffer::FrameHandle& destination);
 FrameRingBuffer::FrameHandle cloneStereoFrame(const FsaiStereoFrame& source);
-std::unique_ptr<FrameRingBuffer> makeFrameRingBuffer(std::size_t capacity);
+std::shared_ptr<FrameRingBuffer> makeFrameRingBuffer(std::size_t capacity);
+void setActiveFrameRingBuffer(std::shared_ptr<FrameRingBuffer> buffer);
+std::shared_ptr<FrameRingBuffer> getActiveFrameRingBuffer();
 
 }  // namespace fsai::vision
 


### PR DESCRIPTION
## Summary
- add support for sharing captured stereo frames through a FrameRingBuffer and expose the active buffer for other subsystems
- initialize and tear down the ring buffer alongside the simulator loop and copy captured frames into it every iteration
- introduce CLI/YAML configuration to enable or disable the edge-detection preview window for headless runs

## Testing
- cmake -S . -B build *(fails: missing Eigen3 in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690631f3df80832485b7c59e6bc91708