### PR TITLE
Add stereo edge preview worker and panel

### DIFF
--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -665,7 +665,7 @@ void DrawLogConsole() {
   ImGui::End();
 }
 
-void DrawEdgePreviewPanel(const fsai::vision::EdgePreview& preview, uint64_t now_ns) {
+void DrawEdgePreviewPanel(fsai::vision::EdgePreview& preview, uint64_t now_ns) {
   ImGui::Begin("Edge Preview");
 
   const auto snapshot = preview.snapshot();

--- a/vision_test/runtime_cpp/include/vision/edge_preview.hpp
+++ b/vision_test/runtime_cpp/include/vision/edge_preview.hpp
@@ -46,7 +46,7 @@ class EdgePreview {
   void stop();
 
   [[nodiscard]] bool running() const;
-  [[nodiscard]] Snapshot snapshot() const;
+  [[nodiscard]] Snapshot snapshot();
   [[nodiscard]] std::string statusMessage() const;
 
  private:
@@ -64,7 +64,12 @@ class EdgePreview {
   int height_ = 0;
   uint64_t last_frame_timestamp_ns_ = 0;
   std::string last_error_;
-  std::vector<uint8_t> upload_buffer_;
+  std::vector<uint8_t> worker_buffer_;
+  std::vector<uint8_t> pending_buffer_;
+  bool pending_ready_ = false;
+  int pending_width_ = 0;
+  int pending_height_ = 0;
+  uint64_t pending_timestamp_ns_ = 0;
 };
 
 }  // namespace fsai::vision

--- a/vision_test/runtime_cpp/include/vision/edge_preview.hpp
+++ b/vision_test/runtime_cpp/include/vision/edge_preview.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <SDL.h>
+
+#include "vision/frame_ring_buffer.hpp"
+
+#ifndef FSAI_EDGE_PREVIEW_HAS_OPENCV
+#  if defined(__has_include)
+#    if __has_include(<opencv2/imgproc.hpp>)
+#      define FSAI_EDGE_PREVIEW_HAS_OPENCV 1
+#    else
+#      define FSAI_EDGE_PREVIEW_HAS_OPENCV 0
+#    endif
+#  else
+#    define FSAI_EDGE_PREVIEW_HAS_OPENCV 1
+#  endif
+#endif
+
+namespace fsai::vision {
+
+class EdgePreview {
+ public:
+  struct Snapshot {
+    std::shared_ptr<SDL_Texture> texture;
+    int width = 0;
+    int height = 0;
+    uint64_t frame_timestamp_ns = 0;
+  };
+
+  EdgePreview();
+  ~EdgePreview();
+
+  EdgePreview(const EdgePreview&) = delete;
+  EdgePreview& operator=(const EdgePreview&) = delete;
+
+  bool start(SDL_Renderer* renderer, std::shared_ptr<FrameRingBuffer> buffer,
+             std::string& error_message);
+  void stop();
+
+  [[nodiscard]] bool running() const;
+  [[nodiscard]] Snapshot snapshot() const;
+  [[nodiscard]] std::string statusMessage() const;
+
+ private:
+  void workerLoop();
+  bool ensureTextureLocked(int width, int height);
+
+  SDL_Renderer* renderer_ = nullptr;
+  std::weak_ptr<FrameRingBuffer> buffer_;
+  std::thread worker_;
+  std::atomic<bool> running_{false};
+
+  mutable std::mutex mutex_;
+  std::shared_ptr<SDL_Texture> texture_;
+  int width_ = 0;
+  int height_ = 0;
+  uint64_t last_frame_timestamp_ns_ = 0;
+  std::string last_error_;
+  std::vector<uint8_t> upload_buffer_;
+};
+
+}  // namespace fsai::vision
+

--- a/vision_test/runtime_cpp/src/CMakeLists.txt
+++ b/vision_test/runtime_cpp/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(VISION_RUNTIME_SOURCES
+  edge_preview.cpp
   detect.cpp
   frame_ring_buffer.cpp
 )
@@ -11,10 +12,12 @@ target_include_directories(fsai_vision_runtime
     ${CMAKE_SOURCE_DIR}/common/include
     ${CMAKE_SOURCE_DIR}/common/include/common
     ${OpenCV_INCLUDE_DIRS}
+    ${SDL2_INCLUDE_DIRS}
 )
 
 target_link_libraries(fsai_vision_runtime
   PUBLIC
     ${OpenCV_LIBS}
+    ${SDL2_IMPORTED_TARGET}
 )
 

--- a/vision_test/runtime_cpp/src/edge_preview.cpp
+++ b/vision_test/runtime_cpp/src/edge_preview.cpp
@@ -1,0 +1,232 @@
+#include "vision/edge_preview.hpp"
+
+#include <chrono>
+#include <utility>
+
+#if FSAI_EDGE_PREVIEW_HAS_OPENCV
+#include <opencv2/imgproc.hpp>
+#endif
+
+namespace fsai::vision {
+
+namespace {
+constexpr std::chrono::milliseconds kIdleSleep{5};
+constexpr std::chrono::milliseconds kBufferMissingSleep{50};
+
+std::shared_ptr<SDL_Texture> makeTexture(SDL_Renderer* renderer, int width, int height) {
+  SDL_Texture* raw = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA32,
+                                       SDL_TEXTUREACCESS_STREAMING, width, height);
+  if (!raw) {
+    return nullptr;
+  }
+  if (SDL_SetTextureBlendMode(raw, SDL_BLENDMODE_BLEND) != 0) {
+    SDL_DestroyTexture(raw);
+    return nullptr;
+  }
+  return std::shared_ptr<SDL_Texture>(raw, [](SDL_Texture* texture) {
+    if (texture) {
+      SDL_DestroyTexture(texture);
+    }
+  });
+}
+}  // namespace
+
+EdgePreview::EdgePreview() = default;
+
+EdgePreview::~EdgePreview() { stop(); }
+
+bool EdgePreview::start(SDL_Renderer* renderer,
+                        std::shared_ptr<FrameRingBuffer> buffer,
+                        std::string& error_message) {
+  error_message.clear();
+
+  if (running_.load()) {
+    return true;
+  }
+
+  if (!renderer) {
+    error_message = "Invalid SDL renderer";
+    std::lock_guard<std::mutex> lock(mutex_);
+    last_error_ = error_message;
+    return false;
+  }
+
+  if (!buffer) {
+    error_message = "Stereo frame buffer unavailable";
+    std::lock_guard<std::mutex> lock(mutex_);
+    last_error_ = error_message;
+    return false;
+  }
+
+#if !FSAI_EDGE_PREVIEW_HAS_OPENCV
+  error_message = "OpenCV imgproc module not available";
+  std::lock_guard<std::mutex> lock(mutex_);
+  last_error_ = error_message;
+  return false;
+#else
+  SDL_RendererInfo info{};
+  if (SDL_GetRendererInfo(renderer, &info) != 0) {
+    error_message = SDL_GetError();
+    std::lock_guard<std::mutex> lock(mutex_);
+    last_error_ = error_message;
+    return false;
+  }
+  if ((info.flags & SDL_RENDERER_ACCELERATED) == 0u) {
+    error_message = "SDL renderer lacks GPU acceleration";
+    std::lock_guard<std::mutex> lock(mutex_);
+    last_error_ = error_message;
+    return false;
+  }
+
+  renderer_ = renderer;
+  buffer_ = buffer;
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    texture_.reset();
+    width_ = 0;
+    height_ = 0;
+    last_frame_timestamp_ns_ = 0;
+    last_error_.clear();
+    upload_buffer_.clear();
+  }
+
+  running_.store(true);
+  try {
+    worker_ = std::thread(&EdgePreview::workerLoop, this);
+  } catch (...) {
+    running_.store(false);
+    error_message = "Failed to start edge preview worker thread";
+    std::lock_guard<std::mutex> lock(mutex_);
+    last_error_ = error_message;
+    return false;
+  }
+
+  return true;
+#endif
+}
+
+void EdgePreview::stop() {
+  const bool was_running = running_.exchange(false);
+  if (was_running && worker_.joinable()) {
+    worker_.join();
+  }
+  buffer_.reset();
+  renderer_ = nullptr;
+  std::lock_guard<std::mutex> lock(mutex_);
+  texture_.reset();
+  width_ = 0;
+  height_ = 0;
+  last_frame_timestamp_ns_ = 0;
+  upload_buffer_.clear();
+}
+
+bool EdgePreview::running() const { return running_.load(); }
+
+EdgePreview::Snapshot EdgePreview::snapshot() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  Snapshot snapshot;
+  snapshot.texture = texture_;
+  snapshot.width = width_;
+  snapshot.height = height_;
+  snapshot.frame_timestamp_ns = last_frame_timestamp_ns_;
+  return snapshot;
+}
+
+std::string EdgePreview::statusMessage() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return last_error_;
+}
+
+bool EdgePreview::ensureTextureLocked(int width, int height) {
+  if (texture_ && width_ == width && height_ == height) {
+    return true;
+  }
+
+  texture_.reset();
+  width_ = 0;
+  height_ = 0;
+
+  auto texture = makeTexture(renderer_, width, height);
+  if (!texture) {
+    last_error_ = SDL_GetError();
+    return false;
+  }
+
+  texture_ = std::move(texture);
+  width_ = width;
+  height_ = height;
+  return true;
+}
+
+void EdgePreview::workerLoop() {
+#if !FSAI_EDGE_PREVIEW_HAS_OPENCV
+  return;
+#else
+  while (running_.load()) {
+    auto buffer = buffer_.lock();
+    if (!buffer) {
+      std::this_thread::sleep_for(kBufferMissingSleep);
+      continue;
+    }
+
+    auto handle = buffer->tryPop();
+    if (!handle.has_value()) {
+      std::this_thread::sleep_for(kIdleSleep);
+      continue;
+    }
+
+    FrameRingBuffer::FrameHandle frame_handle = std::move(*handle);
+    while (auto next = buffer->tryPop()) {
+      frame_handle = std::move(*next);
+    }
+
+    const FsaiFrame& left = frame_handle.frame.left;
+    if (!left.data || left.w <= 0 || left.h <= 0 || left.stride <= 0 ||
+        left.fmt != FSAI_PIXEL_RGB888) {
+      continue;
+    }
+
+    cv::Mat left_rgb(left.h, left.w, CV_8UC3, left.data,
+                     static_cast<size_t>(left.stride));
+    cv::Mat gray;
+    cv::cvtColor(left_rgb, gray, cv::COLOR_RGB2GRAY);
+    cv::Mat blurred;
+    cv::GaussianBlur(gray, blurred, cv::Size(5, 5), 1.2);
+    cv::Mat grad_x;
+    cv::Mat grad_y;
+    cv::Sobel(blurred, grad_x, CV_16S, 1, 0, 3);
+    cv::Sobel(blurred, grad_y, CV_16S, 0, 1, 3);
+    cv::Mat abs_grad_x;
+    cv::Mat abs_grad_y;
+    cv::convertScaleAbs(grad_x, abs_grad_x);
+    cv::convertScaleAbs(grad_y, abs_grad_y);
+    cv::Mat grad;
+    cv::addWeighted(abs_grad_x, 0.5, abs_grad_y, 0.5, 0.0, grad);
+    cv::Mat edges;
+    cv::Canny(grad, edges, 50.0, 150.0);
+
+    const std::size_t pixel_count =
+        static_cast<std::size_t>(left.w) * static_cast<std::size_t>(left.h);
+    upload_buffer_.resize(pixel_count * 4u);
+    cv::Mat rgba(left.h, left.w, CV_8UC4, upload_buffer_.data(),
+                 static_cast<size_t>(left.w) * 4u);
+    cv::cvtColor(edges, rgba, cv::COLOR_GRAY2RGBA);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!ensureTextureLocked(left.w, left.h)) {
+      continue;
+    }
+    if (SDL_UpdateTexture(texture_.get(), nullptr, upload_buffer_.data(), left.w * 4) != 0) {
+      last_error_ = SDL_GetError();
+      continue;
+    }
+    last_error_.clear();
+    last_frame_timestamp_ns_ = frame_handle.frame.t_sync_ns != 0
+                                   ? frame_handle.frame.t_sync_ns
+                                   : left.t_ns;
+  }
+#endif
+}
+
+}  // namespace fsai::vision
+


### PR DESCRIPTION
## Summary
- add an SDL-backed edge preview worker that consumes stereo frames and runs OpenCV Sobel/Canny filtering
- expose the processed texture to ImGui with a new Edge Preview panel in fsai_run and graceful fallbacks when unavailable
- update the vision runtime build to compile the new module and link against SDL2

## Testing
- cmake -S . -B build *(fails: missing Eigen3 package)*

------
https://chatgpt.com/codex/tasks/task_e_6906382cbfb88324bd8658acece72b62