### PR TITLE
Add start cone output to C++ track generator

### DIFF
--- a/control/centerline.prot.cpp
+++ b/control/centerline.prot.cpp
@@ -180,6 +180,7 @@ Triangulation getVisibleTrackTriangulation(
       }
     };
 
+    addCones(fullTrack.startCones);
     addCones(fullTrack.leftCones);
     addCones(fullTrack.rightCones);
 
@@ -217,6 +218,9 @@ int main(int argc, char* argv[])
     Point carFront = generateVehicleTriangulation(CarT, track);
 
     auto t1 = high_resolution_clock::now();
+    for (int i = 0; i < track.startCones.size(); i++) {
+      T.insert(Point(track.startCones[i].position.x, track.startCones[i].position.z));
+    }
     for (int i = 0; i < track.leftCones.size(); i++) {
       T.insert(Point(track.leftCones[i].position.x, track.leftCones[i].position.z));
     }

--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -41,6 +41,7 @@ public:
     const std::vector<Vector3>& checkpointPositionsWorld() const {
         return checkpointPositions;
     }
+    const std::vector<Vector3>& startConePositions() const { return startCones; }
     const std::vector<Vector3>& leftConePositions() const { return leftCones; }
     const std::vector<Vector3>& rightConePositions() const { return rightCones; }
     const LookaheadIndices& lookahead() const { return lookaheadIndices; }
@@ -67,6 +68,7 @@ private:
     Transform carTransform{};
 
     std::vector<Vector3> checkpointPositions{};
+    std::vector<Vector3> startCones{};
     std::vector<Vector3> leftCones{};
     std::vector<Vector3> rightCones{};
     Vector3 lastCheckpoint{0.0f, 0.0f, 0.0f};

--- a/sim/include/sim/track/TrackGenerator.hpp
+++ b/sim/include/sim/track/TrackGenerator.hpp
@@ -6,6 +6,8 @@
 #include <complex>
 
 struct TrackResult {
+    // Large orange cones marking the start line (two pairs).
+    std::vector<Transform> startCones;
     std::vector<Transform> leftCones;
     std::vector<Transform> rightCones;
     std::vector<Transform> checkpoints;
@@ -26,8 +28,13 @@ private:
     static std::vector<std::complex<double>> resampleBoundary(const std::vector<std::complex<double>>& points, int nResample);
     static Vector3 complexToVector3(const std::complex<double>& z);
     static double complexToAngle(const std::complex<double>& z);
-    static int placeCones(const std::vector<std::complex<double>>& points, const std::vector<double>& radii, int side,
-                          double minConeSpacing, double maxConeSpacing, double minCornerRadius, double trackWidth,
-                          double coneSpacingBias, std::vector<std::complex<double>>& selectedPoints);
+    static std::vector<std::complex<double>> placeCones(const std::vector<std::complex<double>>& points,
+                                                        const std::vector<double>& radii,
+                                                        int side,
+                                                        double minConeSpacing,
+                                                        double maxConeSpacing,
+                                                        double minCornerRadius,
+                                                        double trackWidth,
+                                                        double coneSpacingBias);
 };
 

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -46,10 +46,14 @@ void World::init(const char* yamlFilePath) {
 
     // Store checkpoint and cone data
     checkpointPositions.clear();
+    startCones.clear();
     leftCones.clear();
     rightCones.clear();
     for (const auto& cp : track.checkpoints) {
         checkpointPositions.push_back(transformToVector3(cp));
+    }
+    for (const auto& sc : track.startCones) {
+        startCones.push_back(transformToVector3(sc));
     }
     for (const auto& lc : track.leftCones) {
         leftCones.push_back(transformToVector3(lc));
@@ -173,6 +177,16 @@ bool World::detectCollisions() {
         totalDistance = 0.0;
     }
 
+    for (const auto& cone : startCones) {
+        float cdx = carTransform.position.x - cone.x;
+        float cdz = carTransform.position.z - cone.z;
+        float cdist = std::sqrt(cdx * cdx + cdz * cdz);
+        if (cdist < config.coneCollisionThreshold) {
+            std::printf("Collision with a cone detected.\n");
+            reset();
+            return false;
+        }
+    }
     for (const auto& cone : leftCones) {
         float cdx = carTransform.position.x - cone.x;
         float cdz = carTransform.position.z - cone.z;
@@ -229,10 +243,14 @@ void World::reset() {
         TrackResult track = trackGen.generateTrack(pathConfig, path);
 
         checkpointPositions.clear();
+        startCones.clear();
         leftCones.clear();
         rightCones.clear();
         for (const auto& cp : track.checkpoints) {
             checkpointPositions.push_back(transformToVector3(cp));
+        }
+        for (const auto& sc : track.startCones) {
+            startCones.push_back(transformToVector3(sc));
         }
         for (const auto& lc : track.leftCones) {
             leftCones.push_back(transformToVector3(lc));

--- a/sim/src/track/tests/TestTrackGeneration.cpp
+++ b/sim/src/track/tests/TestTrackGeneration.cpp
@@ -28,6 +28,13 @@ int main() {
     }
     fp.close();
 
+    fp.open("start_cones.csv");
+    fp << "x,y,z,rotation\n";
+    for (const auto& t : track.startCones) {
+        fp << t.position.x << ',' << t.position.y << ',' << t.position.z << ',' << t.yaw << '\n';
+    }
+    fp.close();
+
     fp.open("checkpoints.csv");
     fp << "x,y,z,rotation\n";
     for (const auto& t : track.checkpoints) {
@@ -35,7 +42,7 @@ int main() {
     }
     fp.close();
 
-    std::cout << "Data written to left_cones.csv, right_cones.csv, and checkpoints.csv" << std::endl;
+    std::cout << "Data written to left_cones.csv, right_cones.csv, start_cones.csv, and checkpoints.csv" << std::endl;
     int ret = std::system("python ../PathLogic/plot_track.py");
     if (ret != 0) {
         std::cerr << "Graphing tool did not run successfully. Please run plot_track.py manually." << std::endl;


### PR DESCRIPTION
## Summary
- extend the C++ track generator to emit start cones separately from boundary cones and mark them as large orange
- expose the start cone data throughout the simulation stack, including world collision tracking and centerline tooling
- update the track generation test harness to export start cone CSV data alongside other cone outputs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6906963e29308324bff36fee7a203471