### PR TITLE
Refine cone modelling in world simulation

### DIFF
--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -13,6 +13,19 @@
 #include "PathGenerator.hpp"
 #include "TrackGenerator.hpp"
 
+enum class ConeType {
+    Start,
+    Left,
+    Right,
+};
+
+struct Cone {
+    Vector3 position{0.0f, 0.0f, 0.0f};
+    float radius{0.0f};
+    float mass{0.0f};
+    ConeType type{ConeType::Left};
+};
+
 class World {
 public:
     World() = default;
@@ -41,9 +54,9 @@ public:
     const std::vector<Vector3>& checkpointPositionsWorld() const {
         return checkpointPositions;
     }
-    const std::vector<Vector3>& startConePositions() const { return startCones; }
-    const std::vector<Vector3>& leftConePositions() const { return leftCones; }
-    const std::vector<Vector3>& rightConePositions() const { return rightCones; }
+    const std::vector<Cone>& startConePositions() const { return startCones; }
+    const std::vector<Cone>& leftConePositions() const { return leftCones; }
+    const std::vector<Cone>& rightConePositions() const { return rightCones; }
     const LookaheadIndices& lookahead() const { return lookaheadIndices; }
     const WheelsInfo& wheelsInfo() const { return wheelsInfo_; }
     double lapTimeSeconds() const { return totalTime; }
@@ -68,9 +81,9 @@ private:
     Transform carTransform{};
 
     std::vector<Vector3> checkpointPositions{};
-    std::vector<Vector3> startCones{};
-    std::vector<Vector3> leftCones{};
-    std::vector<Vector3> rightCones{};
+    std::vector<Cone> startCones{};
+    std::vector<Cone> leftCones{};
+    std::vector<Cone> rightCones{};
     Vector3 lastCheckpoint{0.0f, 0.0f, 0.0f};
 
     WheelsInfo wheelsInfo_{WheelsInfo_default()};
@@ -81,7 +94,7 @@ private:
 
     struct Config {
         float collisionThreshold{2.5f};
-        float coneCollisionThreshold{0.5f};
+        float vehicleCollisionRadius{0.386f};
         float lapCompletionThreshold{0.1f};
     } config{};
 

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -4,9 +4,38 @@
 #include "fsai_clock.h"
 #include "World.hpp"
 
-static Vector3 transformToVector3(const Transform& t) {
+namespace {
+
+constexpr float kSmallConeBaseWidthMeters = 0.228f;
+constexpr float kLargeConeBaseWidthMeters = 0.285f;
+constexpr float kSmallConeRadiusMeters = kSmallConeBaseWidthMeters / 2.0f;
+constexpr float kLargeConeRadiusMeters = kLargeConeBaseWidthMeters / 2.0f;
+constexpr float kSmallConeMassKg = 0.45f;
+constexpr float kLargeConeMassKg = 1.05f;
+
+Vector3 transformToVector3(const Transform& t) {
     return {t.position.x, t.position.y, t.position.z};
 }
+
+Cone makeCone(const Transform& t, ConeType type) {
+    Cone cone;
+    cone.position = transformToVector3(t);
+    cone.type = type;
+    switch (type) {
+        case ConeType::Start:
+            cone.radius = kLargeConeRadiusMeters;
+            cone.mass = kLargeConeMassKg;
+            break;
+        case ConeType::Left:
+        case ConeType::Right:
+            cone.radius = kSmallConeRadiusMeters;
+            cone.mass = kSmallConeMassKg;
+            break;
+    }
+    return cone;
+}
+
+}  // namespace
 
 bool World::computeRacingControl(double dt, float& throttle_out, float& steering_out) {
     if (!useController || checkpointPositions.empty()) {
@@ -53,13 +82,13 @@ void World::init(const char* yamlFilePath) {
         checkpointPositions.push_back(transformToVector3(cp));
     }
     for (const auto& sc : track.startCones) {
-        startCones.push_back(transformToVector3(sc));
+        startCones.push_back(makeCone(sc, ConeType::Start));
     }
     for (const auto& lc : track.leftCones) {
-        leftCones.push_back(transformToVector3(lc));
+        leftCones.push_back(makeCone(lc, ConeType::Left));
     }
     for (const auto& rc : track.rightCones) {
-        rightCones.push_back(transformToVector3(rc));
+        rightCones.push_back(makeCone(rc, ConeType::Right));
     }
     if (!track.checkpoints.empty()) {
         lastCheckpoint = transformToVector3(track.checkpoints.back());
@@ -75,7 +104,7 @@ void World::init(const char* yamlFilePath) {
 
     // Controller configuration
     config.collisionThreshold = 2.5f;
-    config.coneCollisionThreshold = 0.5f;
+    config.vehicleCollisionRadius = 0.5f - kSmallConeRadiusMeters;
     config.lapCompletionThreshold = 0.1f;
 
     // Use racing algorithm by default
@@ -178,30 +207,33 @@ bool World::detectCollisions() {
     }
 
     for (const auto& cone : startCones) {
-        float cdx = carTransform.position.x - cone.x;
-        float cdz = carTransform.position.z - cone.z;
+        float cdx = carTransform.position.x - cone.position.x;
+        float cdz = carTransform.position.z - cone.position.z;
         float cdist = std::sqrt(cdx * cdx + cdz * cdz);
-        if (cdist < config.coneCollisionThreshold) {
+        const float combinedRadius = cone.radius + config.vehicleCollisionRadius;
+        if (cdist < combinedRadius) {
             std::printf("Collision with a cone detected.\n");
             reset();
             return false;
         }
     }
     for (const auto& cone : leftCones) {
-        float cdx = carTransform.position.x - cone.x;
-        float cdz = carTransform.position.z - cone.z;
+        float cdx = carTransform.position.x - cone.position.x;
+        float cdz = carTransform.position.z - cone.position.z;
         float cdist = std::sqrt(cdx * cdx + cdz * cdz);
-        if (cdist < config.coneCollisionThreshold) {
+        const float combinedRadius = cone.radius + config.vehicleCollisionRadius;
+        if (cdist < combinedRadius) {
             std::printf("Collision with a cone detected.\n");
             reset();
             return false;
         }
     }
     for (const auto& cone : rightCones) {
-        float cdx = carTransform.position.x - cone.x;
-        float cdz = carTransform.position.z - cone.z;
+        float cdx = carTransform.position.x - cone.position.x;
+        float cdz = carTransform.position.z - cone.position.z;
         float cdist = std::sqrt(cdx * cdx + cdz * cdz);
-        if (cdist < config.coneCollisionThreshold) {
+        const float combinedRadius = cone.radius + config.vehicleCollisionRadius;
+        if (cdist < combinedRadius) {
             std::printf("Collision with a cone detected.\n");
             reset();
             return false;
@@ -250,13 +282,13 @@ void World::reset() {
             checkpointPositions.push_back(transformToVector3(cp));
         }
         for (const auto& sc : track.startCones) {
-            startCones.push_back(transformToVector3(sc));
+            startCones.push_back(makeCone(sc, ConeType::Start));
         }
         for (const auto& lc : track.leftCones) {
-            leftCones.push_back(transformToVector3(lc));
+            leftCones.push_back(makeCone(lc, ConeType::Left));
         }
         for (const auto& rc : track.rightCones) {
-            rightCones.push_back(transformToVector3(rc));
+            rightCones.push_back(makeCone(rc, ConeType::Right));
         }
         if (!track.checkpoints.empty()) {
             lastCheckpoint = transformToVector3(track.checkpoints.back());


### PR DESCRIPTION
## Summary
- add typed cone metadata (radius, mass, type) to the world model and use it for collision checks
- ensure start cones remain fixed across lap resets while reusing updated cone generation
- update simulator rendering and telemetry paths to consume cone properties and include start cones in stereo feeds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907793a2f348324b9c0e44c5552ffde