### PR TITLE
Render cones with procedural primitives

### DIFF
--- a/sim/include/sim/cone_constants.hpp
+++ b/sim/include/sim/cone_constants.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace fsai::sim {
+
+inline constexpr float kSmallConeBaseWidthMeters = 0.228f;
+inline constexpr float kLargeConeBaseWidthMeters = 0.285f;
+inline constexpr float kSmallConeRadiusMeters = kSmallConeBaseWidthMeters / 2.0f;
+inline constexpr float kLargeConeRadiusMeters = kLargeConeBaseWidthMeters / 2.0f;
+inline constexpr float kSmallConeMassKg = 0.45f;
+inline constexpr float kLargeConeMassKg = 1.05f;
+
+// Visualisation helpers. Expressed as ratios to avoid duplication across layers.
+inline constexpr float kConeHeightToBaseRatio = 1.35f;
+inline constexpr float kConeStripeHeightFraction = 0.18f;
+inline constexpr float kConeStripeInsetFraction = 0.2f;
+
+}  // namespace fsai::sim
+

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -3,15 +3,14 @@
 #include <cstdio>
 #include "fsai_clock.h"
 #include "World.hpp"
+#include "sim/cone_constants.hpp"
 
 namespace {
 
-constexpr float kSmallConeBaseWidthMeters = 0.228f;
-constexpr float kLargeConeBaseWidthMeters = 0.285f;
-constexpr float kSmallConeRadiusMeters = kSmallConeBaseWidthMeters / 2.0f;
-constexpr float kLargeConeRadiusMeters = kLargeConeBaseWidthMeters / 2.0f;
-constexpr float kSmallConeMassKg = 0.45f;
-constexpr float kLargeConeMassKg = 1.05f;
+using fsai::sim::kLargeConeMassKg;
+using fsai::sim::kLargeConeRadiusMeters;
+using fsai::sim::kSmallConeMassKg;
+using fsai::sim::kSmallConeRadiusMeters;
 
 Vector3 transformToVector3(const Transform& t) {
     return {t.position.x, t.position.y, t.position.z};


### PR DESCRIPTION
## Summary
- add shared cone dimension constants for physics and rendering layers
- render start and course cones using procedurally generated primitives with colored stripes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69077c42f9108324a6a171bfa16f1d9d