### PR TITLE
Update cone generation and rendering for WEMAS specifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build/
 build-linux/
 venv/
+merge_into_main.sh

--- a/docs/DEVLOGS.txt
+++ b/docs/DEVLOGS.txt
@@ -1,29 +1,26 @@
-Finished implementing and testing the DynamicBicycleModel against the Unity counterpart, very similar but there are not the exact same; this may be due to the way C/C++ works; Unity with its own overhead and timing loops could be the cause.
-
-Finished implementing and testing the PathLogic, it's able to reliably generate tracks and checkpoints; visually checked, the high density of checkpoints is never a bad thing; the way the Racing algorithm controller syncs everything together may be the problem.
-
-Racing algorithm testing done by Goat Joshua
-    Fixed compiler warnings
-    Fixed reaction time steering logic
-
-Main Controller actually works with proper graphics
-NOTE: For the manual control to work you have to be on active on the terminal window not the SDL window
-
-    Fixed manual controller (Removed a controller that just drives the car in a circle)
-    Cone Collision detection broken
-    Lap detection broken
-    
-
-- Fixed Cone Collision Detection
-- Crude Lap Completion Detection (Distance based)
-
-TODO:
-    -Write Graphics for Telemetry
-    -Brainstorm Vision Pipeline Integration
-    -Work On Writing A Grid Search To Optimize Racing Algorithm
-    
-BUGS:
+BUGS AND NOTES SIMULATION SUB SYSTEM:
     -Sometimes the car manages to take a wide line completely missing the checkpoint 
-    that is the middle of the track, we need to change the collision box of the checkpoint from a 
-    circle to a straight line across the track so no matter what line it takes it always hits the checkpoint
+    that is the middle of the track, we need to change the collision of the checkpoint from a 
+    circle to a straight line across the track (bridge) so no matter what line it takes it always hits the checkpoint
+
+    -Sometimes the car manages to go through the gap between the cones, bridges need to setup connecting cones so we have a barrier of
+    sorts to prevent the car leaving the track, (considering this as a collision)
+
+    -I think the car is supposed to go anti-clockwise around the track, because from the track generator (as per EUFS)
+    when we get the left cones and right cones and color them as per rules (i.e left -> blue, right -> yellow), and force the
+    car to go clockwise, the blue cones end up being on the right and yellow on left. so currently I have just swapped the
+    colors but we need to swap them back around and make sure the car goes anti clockwise to keep everything consistent...
+
+    -When the controller gets aggressive into braking or under throttle, and the car slips/slides , since relaxing
+    dynamics are not implemented to allow drifting, the car model breaks down and everything explodes... something to implemented
+    later down the line
+
+    -The car controller needs interpolation -> more checkpoints then the available ones (no. of checkpoint = 
+    max(leftcones, rightcones)) to allow smoother driving. Ends up crashing more often than not...
+
+    -The collision boxes are greatly simplified in this simulation, everything is either a square or a circle; so Vision 
+    (which is in charge of collision detection) cannot reliably use the simulation as a backbone to ground truth. actual cone
+    models and cars models need to be made/downloaded from the official repo or made in blender for better realism (this also
+    helps with rendering more realistic lighting effects)...
+    
     

--- a/io/camera/sim_stereo/cone_mesh.cpp
+++ b/io/camera/sim_stereo/cone_mesh.cpp
@@ -1,5 +1,6 @@
 #include "cone_mesh.hpp"
 
+#include <array>
 #include <cmath>
 #include <stdexcept>
 #include <utility>
@@ -9,41 +10,90 @@
 namespace fsai::io::camera::sim_stereo {
 
 namespace {
-constexpr int kSegments = 24;
+constexpr int kSegments = 32;
+constexpr float kBaseHalfExtent = 0.5f;
+constexpr float kBaseHeight = 0.15f;
+constexpr float kBodyBottomRadius = 0.36f;
+constexpr float kBodyTopRadius = 0.1f;
+constexpr float kTipHeight = 1.05f;
 
-ConeVertex makeVertex(float x, float y, float z, float r, float g, float b) {
-  return ConeVertex{{x, y, z}, {r, g, b}};
+ConeVertex makeVertex(float x, float y, float z, float region) {
+  return ConeVertex{{x, y, z}, region};
 }
 
 }  // namespace
 
 ConeMesh::ConeMesh() {
-  vertices_.reserve(kSegments + 2);
+  const std::array<std::pair<float, float>, 4> base_corners = {
+      std::pair{-kBaseHalfExtent, -kBaseHalfExtent},
+      std::pair{kBaseHalfExtent, -kBaseHalfExtent},
+      std::pair{kBaseHalfExtent, kBaseHalfExtent},
+      std::pair{-kBaseHalfExtent, kBaseHalfExtent}};
 
-  vertices_.push_back(makeVertex(0.0f, 0.5f, 0.0f, 1.0f, 0.6f, 0.1f));
+  vertices_.reserve(static_cast<std::size_t>(kSegments) * 2 + 13);
+
+  for (const auto& [x, z] : base_corners) {
+    vertices_.push_back(makeVertex(x, 0.0f, z, 0.0f));
+  }
+  for (const auto& [x, z] : base_corners) {
+    vertices_.push_back(makeVertex(x, kBaseHeight, z, 0.0f));
+  }
+
+  const uint32_t base_top_center = static_cast<uint32_t>(vertices_.size());
+  vertices_.push_back(makeVertex(0.0f, kBaseHeight, 0.0f, 0.0f));
+
+  for (int i = 0; i < 4; ++i) {
+    const uint32_t bottom0 = static_cast<uint32_t>(i);
+    const uint32_t bottom1 = static_cast<uint32_t>((i + 1) % 4);
+    const uint32_t top0 = static_cast<uint32_t>(4 + i);
+    const uint32_t top1 = static_cast<uint32_t>(4 + ((i + 1) % 4));
+    indices_.push_back(bottom0);
+    indices_.push_back(bottom1);
+    indices_.push_back(top1);
+    indices_.push_back(bottom0);
+    indices_.push_back(top1);
+    indices_.push_back(top0);
+    indices_.push_back(base_top_center);
+    indices_.push_back(top0);
+    indices_.push_back(top1);
+  }
+
+  const uint32_t body_bottom_start = static_cast<uint32_t>(vertices_.size());
+  for (int i = 0; i < kSegments; ++i) {
+    const float angle = static_cast<float>(i) / static_cast<float>(kSegments) *
+                       static_cast<float>(2.0 * M_PI);
+    const float x = kBodyBottomRadius * std::cos(angle);
+    const float z = kBodyBottomRadius * std::sin(angle);
+    vertices_.push_back(makeVertex(x, kBaseHeight, z, 1.0f));
+  }
+
+  const uint32_t body_top_start = static_cast<uint32_t>(vertices_.size());
+  for (int i = 0; i < kSegments; ++i) {
+    const float angle = static_cast<float>(i) / static_cast<float>(kSegments) *
+                       static_cast<float>(2.0 * M_PI);
+    const float x = kBodyTopRadius * std::cos(angle);
+    const float z = kBodyTopRadius * std::sin(angle);
+    vertices_.push_back(makeVertex(x, 1.0f, z, 1.0f));
+  }
+
+  const uint32_t tip_index = static_cast<uint32_t>(vertices_.size());
+  vertices_.push_back(makeVertex(0.0f, kTipHeight, 0.0f, 1.0f));
 
   for (int i = 0; i < kSegments; ++i) {
-    float angle = static_cast<float>(i) / static_cast<float>(kSegments) *
-                  static_cast<float>(2.0 * M_PI);
-    float x = 0.25f * std::cos(angle);
-    float z = 0.25f * std::sin(angle);
-    vertices_.push_back(makeVertex(x, 0.0f, z, 1.0f, 0.8f, 0.3f));
+    const uint32_t next = static_cast<uint32_t>((i + 1) % kSegments);
+    indices_.push_back(body_bottom_start + static_cast<uint32_t>(i));
+    indices_.push_back(body_bottom_start + next);
+    indices_.push_back(body_top_start + static_cast<uint32_t>(i));
+    indices_.push_back(body_top_start + static_cast<uint32_t>(i));
+    indices_.push_back(body_bottom_start + next);
+    indices_.push_back(body_top_start + next);
   }
 
   for (int i = 0; i < kSegments; ++i) {
-    uint32_t next = (i + 1) % kSegments;
-    indices_.push_back(0);
-    indices_.push_back(1 + next);
-    indices_.push_back(1 + i);
-  }
-
-  uint32_t base_center = static_cast<uint32_t>(vertices_.size());
-  vertices_.push_back(makeVertex(0.0f, 0.0f, 0.0f, 0.3f, 0.3f, 0.3f));
-  for (int i = 0; i < kSegments; ++i) {
-    uint32_t next = (i + 1) % kSegments;
-    indices_.push_back(base_center);
-    indices_.push_back(1 + i);
-    indices_.push_back(1 + next);
+    const uint32_t next = static_cast<uint32_t>((i + 1) % kSegments);
+    indices_.push_back(tip_index);
+    indices_.push_back(body_top_start + next);
+    indices_.push_back(body_top_start + static_cast<uint32_t>(i));
   }
 }
 
@@ -54,7 +104,8 @@ ConeMesh& ConeMesh::operator=(ConeMesh&& other) noexcept {
     destroyGl();
     vertices_ = std::move(other.vertices_);
     indices_ = std::move(other.indices_);
-    instance_mats_ = std::move(other.instance_mats_);
+    instances_ = std::move(other.instances_);
+    instance_buffer_ = std::move(other.instance_buffer_);
     instance_count_ = other.instance_count_;
     vao_ = other.vao_;
     vbo_ = other.vbo_;
@@ -115,35 +166,63 @@ void ConeMesh::uploadGeometry() {
                         reinterpret_cast<void*>(offsetof(ConeVertex, position)));
 
   glEnableVertexAttribArray(1);
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(ConeVertex),
-                        reinterpret_cast<void*>(offsetof(ConeVertex, color)));
+  glVertexAttribPointer(1, 1, GL_FLOAT, GL_FALSE, sizeof(ConeVertex),
+                        reinterpret_cast<void*>(offsetof(ConeVertex, region)));
 
   glGenBuffers(1, &instance_vbo_);
   glBindBuffer(GL_ARRAY_BUFFER, instance_vbo_);
   glBufferData(GL_ARRAY_BUFFER, 0, nullptr, GL_DYNAMIC_DRAW);
 
-  constexpr std::size_t mat_stride = sizeof(float) * 16;
+  const GLsizei instance_stride =
+      static_cast<GLsizei>((16 + 3 + 3 + 1) * sizeof(float));
+
   for (int i = 0; i < 4; ++i) {
     glEnableVertexAttribArray(2 + i);
-    glVertexAttribPointer(2 + i, 4, GL_FLOAT, GL_FALSE,
-                          static_cast<GLsizei>(mat_stride),
+    glVertexAttribPointer(2 + i, 4, GL_FLOAT, GL_FALSE, instance_stride,
                           reinterpret_cast<void*>(sizeof(float) * 4 * i));
     glVertexAttribDivisor(2 + i, 1);
   }
 
+  const GLsizei color_offset = static_cast<GLsizei>(16 * sizeof(float));
+  glEnableVertexAttribArray(6);
+  glVertexAttribPointer(6, 3, GL_FLOAT, GL_FALSE, instance_stride,
+                        reinterpret_cast<void*>(color_offset));
+  glVertexAttribDivisor(6, 1);
+
+  glEnableVertexAttribArray(7);
+  glVertexAttribPointer(7, 3, GL_FLOAT, GL_FALSE, instance_stride,
+                        reinterpret_cast<void*>(color_offset + 3 * sizeof(float)));
+  glVertexAttribDivisor(7, 1);
+
+  glEnableVertexAttribArray(8);
+  glVertexAttribPointer(8, 1, GL_FLOAT, GL_FALSE, instance_stride,
+                        reinterpret_cast<void*>(color_offset + 6 * sizeof(float)));
+  glVertexAttribDivisor(8, 1);
+
   glBindVertexArray(0);
 }
 
-void ConeMesh::setInstances(const std::vector<float>& matrices4x4) {
-  instance_mats_ = matrices4x4;
-  instance_count_ = instance_mats_.size() / 16;
+void ConeMesh::setInstances(const std::vector<ConeInstanceData>& instances) {
+  instances_ = instances;
+  instance_count_ = instances_.size();
   if (instance_vbo_ == 0) {
     initializeGl();
   }
+  instance_buffer_.clear();
+  instance_buffer_.reserve(instance_count_ * (16 + 3 + 3 + 1));
+  for (const auto& instance : instances_) {
+    instance_buffer_.insert(instance_buffer_.end(), instance.model.begin(),
+                            instance.model.end());
+    instance_buffer_.insert(instance_buffer_.end(), instance.body_color.begin(),
+                            instance.body_color.end());
+    instance_buffer_.insert(instance_buffer_.end(), instance.stripe_color.begin(),
+                            instance.stripe_color.end());
+    instance_buffer_.push_back(instance.stripe_count);
+  }
   glBindBuffer(GL_ARRAY_BUFFER, instance_vbo_);
   glBufferData(GL_ARRAY_BUFFER,
-               static_cast<GLsizeiptr>(instance_mats_.size() * sizeof(float)),
-               instance_mats_.data(), GL_DYNAMIC_DRAW);
+               static_cast<GLsizeiptr>(instance_buffer_.size() * sizeof(float)),
+               instance_buffer_.data(), GL_DYNAMIC_DRAW);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
@@ -160,3 +239,4 @@ void ConeMesh::draw() const {
 }
 
 }  // namespace fsai::io::camera::sim_stereo
+

--- a/io/camera/sim_stereo/cone_mesh.hpp
+++ b/io/camera/sim_stereo/cone_mesh.hpp
@@ -9,7 +9,14 @@ namespace fsai::io::camera::sim_stereo {
 
 struct ConeVertex {
   std::array<float, 3> position;
-  std::array<float, 3> color;
+  float region;
+};
+
+struct ConeInstanceData {
+  std::array<float, 16> model;
+  std::array<float, 3> body_color;
+  std::array<float, 3> stripe_color;
+  float stripe_count;
 };
 
 class ConeMesh {
@@ -24,7 +31,7 @@ class ConeMesh {
   void initializeGl();
   void draw() const;
 
-  void setInstances(const std::vector<float>& matrices4x4);
+  void setInstances(const std::vector<ConeInstanceData>& instances);
   std::size_t instanceCount() const { return instance_count_; }
 
  private:
@@ -33,7 +40,8 @@ class ConeMesh {
 
   std::vector<ConeVertex> vertices_;
   std::vector<uint32_t> indices_;
-  std::vector<float> instance_mats_;
+  std::vector<ConeInstanceData> instances_;
+  std::vector<float> instance_buffer_;
   std::size_t instance_count_ = 0;
 
   unsigned int vao_ = 0;

--- a/io/camera/sim_stereo/shader_program.cpp
+++ b/io/camera/sim_stereo/shader_program.cpp
@@ -125,25 +125,71 @@ void ShaderProgram::setMat4(const char* name, const std::array<float, 16>& matri
 ShaderProgram buildDefaultConeShader() {
   static constexpr const char* kConeVs = R"(#version 330 core
 layout(location = 0) in vec3 in_position;
-layout(location = 1) in vec3 in_color;
+layout(location = 1) in float in_region;
 layout(location = 2) in mat4 in_model;
+layout(location = 6) in vec3 in_body_color;
+layout(location = 7) in vec3 in_stripe_color;
+layout(location = 8) in float in_stripe_count;
 
 uniform mat4 u_view;
 uniform mat4 u_proj;
 
-out vec3 v_color;
+out vec3 v_local_pos;
+flat out float v_region;
+flat out vec3 v_body_color;
+flat out vec3 v_stripe_color;
+flat out float v_stripe_count;
 
 void main() {
-  v_color = in_color;
+  v_local_pos = in_position;
+  v_region = in_region;
+  v_body_color = in_body_color;
+  v_stripe_color = in_stripe_color;
+  v_stripe_count = in_stripe_count;
   gl_Position = u_proj * u_view * in_model * vec4(in_position, 1.0);
 }
 )";
 
   static constexpr const char* kConeFs = R"(#version 330 core
-in vec3 v_color;
+in vec3 v_local_pos;
+flat in float v_region;
+flat in vec3 v_body_color;
+flat in vec3 v_stripe_color;
+flat in float v_stripe_count;
+
 out vec4 out_color;
+
+const float kBaseColor = 0.18;
+const float kStripeHalfWidth = 0.08;
+const int kMaxStripes = 4;
+
 void main() {
-  out_color = vec4(v_color, 1.0);
+  if (v_region < 0.5) {
+    out_color = vec4(kBaseColor, kBaseColor, kBaseColor, 1.0);
+    return;
+  }
+
+  vec3 color = v_body_color;
+  int stripes = int(round(clamp(v_stripe_count, 0.0, float(kMaxStripes))));
+  if (stripes > 0) {
+    float x_norm = clamp(v_local_pos.x + 0.5, 0.0, 1.0);
+    for (int i = 0; i < kMaxStripes; ++i) {
+      if (i >= stripes) {
+        break;
+      }
+      float center = (float(i) + 1.0) / (float(stripes) + 1.0);
+      float delta = abs(x_norm - center);
+      if (delta > 0.5) {
+        delta = 1.0 - delta;
+      }
+      if (delta < kStripeHalfWidth) {
+        color = v_stripe_color;
+        break;
+      }
+    }
+  }
+
+  out_color = vec4(color, 1.0);
 }
 )";
 

--- a/io/camera/sim_stereo/shader_program.cpp
+++ b/io/camera/sim_stereo/shader_program.cpp
@@ -159,7 +159,9 @@ flat in float v_stripe_count;
 
 out vec4 out_color;
 
-const float kStripeHalfWidth = 0.08;
+const float kStripeHalfHeight = 0.11;
+const float kBaseHeight = 0.15;
+const float kTipHeight = 1.05;
 const int kMaxStripes = 4;
 
 void main() {
@@ -171,19 +173,16 @@ void main() {
   vec3 color = v_body_color;
   int stripes = int(round(clamp(v_stripe_count, 0.0, float(kMaxStripes))));
   if (stripes > 0) {
-    const float pi = 3.1415926535897932384626433832795;
-    float angle = atan(v_local_pos.z, v_local_pos.x);
-    float norm_angle = (angle + pi) / (2.0 * pi);
+    float normalized_height = (v_local_pos.y - kBaseHeight) / (kTipHeight - kBaseHeight);
+    normalized_height = clamp(normalized_height, 0.0, 1.0);
+    float denom = float(stripes) + 1.0;
     for (int i = 0; i < kMaxStripes; ++i) {
       if (i >= stripes) {
         break;
       }
-      float center = (float(i) + 0.5) / float(stripes);
-      float delta = abs(norm_angle - center);
-      if (delta > 0.5) {
-        delta = 1.0 - delta;
-      }
-      if (delta < kStripeHalfWidth) {
+      float center = (float(i) + 1.0) / denom;
+      float delta = abs(normalized_height - center);
+      if (delta < kStripeHalfHeight) {
         color = v_stripe_color;
         break;
       }

--- a/io/camera/sim_stereo/shader_program.cpp
+++ b/io/camera/sim_stereo/shader_program.cpp
@@ -159,26 +159,27 @@ flat in float v_stripe_count;
 
 out vec4 out_color;
 
-const float kBaseColor = 0.18;
 const float kStripeHalfWidth = 0.08;
 const int kMaxStripes = 4;
 
 void main() {
   if (v_region < 0.5) {
-    out_color = vec4(kBaseColor, kBaseColor, kBaseColor, 1.0);
+    out_color = vec4(v_body_color, 1.0);
     return;
   }
 
   vec3 color = v_body_color;
   int stripes = int(round(clamp(v_stripe_count, 0.0, float(kMaxStripes))));
   if (stripes > 0) {
-    float x_norm = clamp(v_local_pos.x + 0.5, 0.0, 1.0);
+    const float pi = 3.1415926535897932384626433832795;
+    float angle = atan(v_local_pos.z, v_local_pos.x);
+    float norm_angle = (angle + pi) / (2.0 * pi);
     for (int i = 0; i < kMaxStripes; ++i) {
       if (i >= stripes) {
         break;
       }
-      float center = (float(i) + 1.0) / (float(stripes) + 1.0);
-      float delta = abs(x_norm - center);
+      float center = (float(i) + 0.5) / float(stripes);
+      float delta = abs(norm_angle - center);
       if (delta > 0.5) {
         delta = 1.0 - delta;
       }

--- a/io/camera/sim_stereo/sim_stereo_source.cpp
+++ b/io/camera/sim_stereo/sim_stereo_source.cpp
@@ -79,20 +79,26 @@ void SimStereoSource::ensureGl() {
   }
 }
 
-void SimStereoSource::setCones(
-    const std::vector<std::array<float, 3>>& cones_world) {
+void SimStereoSource::setCones(const std::vector<SimConeInstance>& cones_world) {
   gl_context_.makeCurrent();
-  std::vector<float> matrices;
-  matrices.reserve(cones_world.size() * 16);
-  for (const auto& p : cones_world) {
+  std::vector<ConeInstanceData> instances;
+  instances.reserve(cones_world.size());
+  for (const auto& cone : cones_world) {
     Eigen::Matrix4f model = Eigen::Matrix4f::Identity();
-    model(0, 3) = p[0];
-    model(1, 3) = p[1];
-    model(2, 3) = p[2];
-    auto arr = eigenToArray(model);
-    matrices.insert(matrices.end(), arr.begin(), arr.end());
+    model(0, 0) = cone.base_width;
+    model(1, 1) = cone.height;
+    model(2, 2) = cone.base_width;
+    model(0, 3) = cone.position[0];
+    model(1, 3) = cone.position[1];
+    model(2, 3) = cone.position[2];
+    ConeInstanceData data{};
+    data.model = eigenToArray(model);
+    data.body_color = cone.body_color;
+    data.stripe_color = cone.stripe_color;
+    data.stripe_count = static_cast<float>(cone.stripe_count);
+    instances.push_back(data);
   }
-  cone_mesh_.setInstances(matrices);
+  cone_mesh_.setInstances(instances);
 }
 
 void SimStereoSource::setBodyPose(float x, float y, float z, float yaw) {

--- a/io/camera/sim_stereo/sim_stereo_source.hpp
+++ b/io/camera/sim_stereo/sim_stereo_source.hpp
@@ -26,11 +26,20 @@ struct SimStereoConfig {
   FsaiCameraExtrinsics right_extrinsics{};
 };
 
+struct SimConeInstance {
+  std::array<float, 3> position{0.0f, 0.0f, 0.0f};
+  float base_width = 0.0f;
+  float height = 0.0f;
+  std::array<float, 3> body_color{1.0f, 0.5f, 0.0f};
+  std::array<float, 3> stripe_color{1.0f, 1.0f, 1.0f};
+  int stripe_count = 0;
+};
+
 class SimStereoSource {
  public:
   explicit SimStereoSource(const SimStereoConfig& config);
 
-  void setCones(const std::vector<std::array<float, 3>>& cones_world);
+  void setCones(const std::vector<SimConeInstance>& cones_world);
   void setBodyPose(float x, float y, float z, float yaw);
   const FsaiStereoFrame& capture(uint64_t timestamp_ns);
 

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -767,8 +767,8 @@ void DrawWorldScene(Graphics* graphics, const World& world,
                                         graphics->height / 2.0f);
     DrawConeMarker(graphics, cone_x, cone_y, cone.radius * 2.0f, start_color);
   }
-
-  const SDL_Color left_base{0, 102, 204, 255};
+  // Blue 0, 102, 204, 255
+  const SDL_Color left_base{255, 214, 0, 255};
   for (size_t i = 0; i < world.leftConePositions().size(); ++i) {
     SDL_Color color = left_base;
     if (i == 0) {
@@ -785,8 +785,8 @@ void DrawWorldScene(Graphics* graphics, const World& world,
                                         graphics->height / 2.0f);
     DrawConeMarker(graphics, cone_x, cone_y, cone.radius * 2.0f, color);
   }
-
-  const SDL_Color right_base{255, 214, 0, 255};
+  // Yellow 255, 214, 0, 255
+  const SDL_Color right_base{0, 102, 204, 255};
   for (size_t i = 0; i < world.rightConePositions().size(); ++i) {
     SDL_Color color = right_base;
     if (i == 0) {
@@ -1807,12 +1807,13 @@ int main(int argc, char* argv[]) {
         return std::array<float, 3>{r * color_scale, g * color_scale,
                                     b * color_scale};
       };
+
       const auto start_body = makeColor(255, 140, 0);
       const auto start_stripe = makeColor(255, 255, 255);
-      const auto left_body = makeColor(0, 102, 204);
-      const auto left_stripe = makeColor(255, 255, 255);
-      const auto right_body = makeColor(255, 214, 0);
-      const auto right_stripe = makeColor(50, 50, 50);
+      const auto left_body = makeColor(255, 214, 0);
+      const auto left_stripe = makeColor(50, 50, 50);
+      const auto right_body = makeColor(0, 102, 204);
+      const auto right_stripe = makeColor(255, 255, 255);
 
       auto appendCone = [&](const Cone& cone) {
         fsai::io::camera::sim_stereo::SimConeInstance instance{};

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -758,46 +758,32 @@ void DrawConePrimitive(Graphics* graphics, int center_x, int center_y,
 
   SDL_SetRenderDrawColor(graphics->renderer, style.stripe.r, style.stripe.g,
                          style.stripe.b, style.stripe.a);
-  const int left_bound =
-      static_cast<int>(std::floor(center_x - half_base_px));
-  const int right_bound =
-      static_cast<int>(std::ceil(center_x + half_base_px));
-  const float stripe_fraction_denom =
-      static_cast<float>(style.stripe_count);
   const float stripe_half_fraction =
       fsai::sim::kConeStripeWidthFraction * 0.5f;
+  const float stripe_denom = static_cast<float>(style.stripe_count + 1);
+  const float total_height_f = static_cast<float>(total_height);
 
-  for (int column = left_bound; column <= right_bound; ++column) {
-    const float column_center = static_cast<float>(column) + 0.5f;
-    const float offset = (column_center - center_x) / half_base_px;
-    if (std::abs(offset) > 1.0f) {
-      continue;
+  for (int stripe_index = 0; stripe_index < style.stripe_count; ++stripe_index) {
+    const float center_fraction =
+        (static_cast<float>(stripe_index) + 1.0f) / stripe_denom;
+    const float min_fraction =
+        std::max(0.0f, center_fraction - stripe_half_fraction);
+    const float max_fraction =
+        std::min(1.0f, center_fraction + stripe_half_fraction);
+
+    const int start_row = std::max(
+        0, static_cast<int>(std::floor(min_fraction * total_height_f)));
+    const int end_row = std::min(
+        total_height, static_cast<int>(std::ceil(max_fraction * total_height_f)));
+
+    for (int row = start_row; row <= end_row; ++row) {
+      const float t = static_cast<float>(row) / total_height_f;
+      const float half_width_row = half_base_px * t;
+      const int y = top_y + row;
+      const int left = static_cast<int>(std::round(center_x - half_width_row));
+      const int right = static_cast<int>(std::round(center_x + half_width_row));
+      SDL_RenderDrawLine(graphics->renderer, left, y, right, y);
     }
-
-    const float fraction = offset * 0.5f + 0.5f;
-    bool draw_stripe = false;
-    for (int stripe_index = 0; stripe_index < style.stripe_count; ++stripe_index) {
-      const float center =
-          (static_cast<float>(stripe_index) + 0.5f) / stripe_fraction_denom;
-      float delta = std::abs(fraction - center);
-      if (delta > 0.5f) {
-        delta = 1.0f - delta;
-      }
-      if (delta <= stripe_half_fraction) {
-        draw_stripe = true;
-        break;
-      }
-    }
-
-    if (!draw_stripe) {
-      continue;
-    }
-
-    const float min_t = std::abs(offset);
-    const int stripe_top = top_y +
-        static_cast<int>(std::round(static_cast<float>(total_height) * min_t));
-    const int stripe_bottom = base_y;
-    SDL_RenderDrawLine(graphics->renderer, column, stripe_top, column, stripe_bottom);
   }
 }
 

--- a/sim/include/sim/cone_constants.hpp
+++ b/sim/include/sim/cone_constants.hpp
@@ -6,13 +6,18 @@ inline constexpr float kSmallConeBaseWidthMeters = 0.228f;
 inline constexpr float kLargeConeBaseWidthMeters = 0.285f;
 inline constexpr float kSmallConeRadiusMeters = kSmallConeBaseWidthMeters / 2.0f;
 inline constexpr float kLargeConeRadiusMeters = kLargeConeBaseWidthMeters / 2.0f;
+inline constexpr float kSmallConeHeightMeters = 0.325f;
+inline constexpr float kLargeConeHeightMeters = 0.505f;
 inline constexpr float kSmallConeMassKg = 0.45f;
 inline constexpr float kLargeConeMassKg = 1.05f;
 
-// Visualisation helpers. Expressed as ratios to avoid duplication across layers.
-inline constexpr float kConeHeightToBaseRatio = 1.35f;
-inline constexpr float kConeStripeHeightFraction = 0.18f;
-inline constexpr float kConeStripeInsetFraction = 0.2f;
+inline constexpr float kSmallConeHeightToBaseRatio =
+    kSmallConeHeightMeters / kSmallConeBaseWidthMeters;
+inline constexpr float kLargeConeHeightToBaseRatio =
+    kLargeConeHeightMeters / kLargeConeBaseWidthMeters;
+
+// Visualisation helpers.
+inline constexpr float kConeStripeWidthFraction = 0.22f;
 
 }  // namespace fsai::sim
 

--- a/sim/include/sim/track/TrackGenerator.hpp
+++ b/sim/include/sim/track/TrackGenerator.hpp
@@ -28,6 +28,16 @@ private:
     static std::vector<std::complex<double>> resampleBoundary(const std::vector<std::complex<double>>& points, int nResample);
     static Vector3 complexToVector3(const std::complex<double>& z);
     static double complexToAngle(const std::complex<double>& z);
+    static void pickStartingPoint(std::vector<std::complex<double>>& positions,
+                                  std::vector<std::complex<double>>& normals,
+                                  std::vector<double>& radii,
+                                  double startingStraightLength,
+                                  int downsample);
+    static int findCarIndex(const std::vector<std::complex<double>>& positions,
+                            double startOffset);
+    static void applyTransform(std::vector<std::complex<double>>& points,
+                               const std::complex<double>& translation,
+                               const std::complex<double>& rotation);
     static std::vector<std::complex<double>> placeCones(const std::vector<std::complex<double>>& points,
                                                         const std::vector<double>& radii,
                                                         int side,

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -102,9 +102,9 @@ void World::init(const char* yamlFilePath) {
     deltaTime = 0.0;
 
     // Controller configuration
-    config.collisionThreshold = 2.5f;
+    config.collisionThreshold = 1.75f;
     config.vehicleCollisionRadius = 0.5f - kSmallConeRadiusMeters;
-    config.lapCompletionThreshold = 0.1f;
+    config.lapCompletionThreshold = 0.2f;
 
     // Use racing algorithm by default
     useController = 1;
@@ -113,9 +113,9 @@ void World::init(const char* yamlFilePath) {
     regenTrack = 1;
 
     // Racing algorithm configuration
-    racingConfig.speedLookAheadSensitivity = 0.6f;
-    racingConfig.steeringLookAheadSensitivity = 0.05f;
-    racingConfig.accelerationFactor = 0.002f;
+    racingConfig.speedLookAheadSensitivity = 0.5f;
+    racingConfig.steeringLookAheadSensitivity = 0;
+    racingConfig.accelerationFactor = 0.0019f;
 
     // Make sure car starts on the track
     float startX = checkpointPositions[0].x;

--- a/sim/src/track/TrackGenerator.cpp
+++ b/sim/src/track/TrackGenerator.cpp
@@ -372,6 +372,17 @@ TrackResult TrackGenerator::generateTrack(const PathConfig& config, const PathRe
         rightConesC.erase(rightConesC.begin());
     }
 
+    if (leftConesC.size() > 1 && rightConesC.size() > 1) {
+        const cdouble center0 = 0.5 * (leftConesC[0] + rightConesC[0]);
+        const cdouble center1 = 0.5 * (leftConesC[1] + rightConesC[1]);
+        const cdouble forward = center1 - center0;
+        const cdouble to_left = leftConesC[0] - center0;
+        const double cross = forward.real() * to_left.imag() - forward.imag() * to_left.real();
+        if (cross < 0.0) {
+            leftConesC.swap(rightConesC);
+        }
+    }
+
     int nResample = static_cast<int>(std::min(leftConesC.size(), rightConesC.size()));
     if (nResample < 2) throw std::runtime_error("Not enough cones on one side to compute a racing line.");
 

--- a/sim/src/track/TrackGenerator.cpp
+++ b/sim/src/track/TrackGenerator.cpp
@@ -1,6 +1,8 @@
 #include "TrackGenerator.hpp"
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <numeric>
 #include <stdexcept>
 
 using cdouble = std::complex<double>;
@@ -86,6 +88,172 @@ double TrackGenerator::complexToAngle(const cdouble& z) {
     return std::atan2(z.imag(), z.real());
 }
 
+namespace {
+
+std::vector<double> downsampleDistances(const std::vector<cdouble>& points) {
+    const int count = static_cast<int>(points.size());
+    std::vector<double> distances(count, 0.0);
+    if (count == 0) {
+        return distances;
+    }
+    for (int i = 0; i < count; ++i) {
+        const int next = (i + 1) % count;
+        distances[i] = std::abs(points[next] - points[i]);
+    }
+    return distances;
+}
+
+double computeTrackLength(const std::vector<cdouble>& positions) {
+    double length = 0.0;
+    const int count = static_cast<int>(positions.size());
+    for (int i = 0; i < count; ++i) {
+        const int next = (i + 1) % count;
+        length += std::abs(positions[next] - positions[i]);
+    }
+    return length;
+}
+
+}  // namespace
+
+void TrackGenerator::pickStartingPoint(std::vector<cdouble>& positions,
+                                       std::vector<cdouble>& normals,
+                                       std::vector<double>& radii,
+                                       double startingStraightLength,
+                                       int downsample) {
+    const int nPoints = static_cast<int>(positions.size());
+    if (nPoints == 0) {
+        return;
+    }
+
+    if (downsample < 1) {
+        downsample = 1;
+    }
+
+    std::vector<cdouble> dsPositions;
+    std::vector<double> dsCurvature;
+    dsPositions.reserve(nPoints / downsample + 1);
+    dsCurvature.reserve(nPoints / downsample + 1);
+
+    for (int i = 0; i < nPoints; i += downsample) {
+        dsPositions.push_back(positions[i]);
+        const double radius = radii[i];
+        double curvature = 0.0;
+        if (radius != 0.0) {
+            curvature = std::abs(1.0 / radius);
+        } else {
+            curvature = std::numeric_limits<double>::infinity();
+        }
+        dsCurvature.push_back(curvature);
+    }
+
+    const int dsCount = static_cast<int>(dsPositions.size());
+    if (dsCount == 0) {
+        return;
+    }
+
+    std::vector<int> sortedIndices(dsCount);
+    std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
+    std::sort(sortedIndices.begin(), sortedIndices.end(),
+              [&](int a, int b) { return dsCurvature[a] < dsCurvature[b]; });
+
+    const int candidateCount = std::max(1, dsCount / 8);
+    const double smoothDiameter = 1.5 * startingStraightLength;
+    const std::vector<double> dsDistances = downsampleDistances(dsPositions);
+
+    auto smoothedCurvature = [&](int index) {
+        double value = dsCurvature[index];
+        double coefSum = 1.0;
+        if (dsCount <= 1) {
+            return value;
+        }
+        int current = (index == 0) ? dsCount - 1 : index - 1;
+        double distance = dsDistances[current];
+        while (distance < smoothDiameter && dsCount > 1) {
+            const double coef = dsDistances[current] *
+                                std::sin(M_PI * distance / smoothDiameter);
+            value += coef * dsCurvature[current];
+            coefSum += coef;
+            current = (current == 0) ? dsCount - 1 : current - 1;
+            distance += dsDistances[current];
+        }
+        return coefSum > 0.0 ? value / coefSum : value;
+    };
+
+    double bestValue = std::numeric_limits<double>::infinity();
+    int bestIndex = 0;
+    for (int i = 0; i < candidateCount && i < dsCount; ++i) {
+        const int candidate = sortedIndices[i];
+        const double smoothed = smoothedCurvature(candidate);
+        if (smoothed < bestValue) {
+            bestValue = smoothed;
+            bestIndex = candidate;
+        }
+    }
+
+    const int startIndex = (bestIndex * downsample) % nPoints;
+
+    auto rotateVector = [&](auto& vec) {
+        std::rotate(vec.begin(), vec.begin() + startIndex, vec.end());
+    };
+    rotateVector(positions);
+    rotateVector(normals);
+    rotateVector(radii);
+
+    const cdouble startPosition = positions.front();
+    for (auto& p : positions) {
+        p -= startPosition;
+    }
+
+    const cdouble startNormal = normals.front();
+    cdouble rotation = cdouble(0.0, 1.0);
+    if (std::abs(startNormal) > 0.0) {
+        rotation = cdouble(0.0, 1.0) / startNormal;
+    }
+    for (auto& p : positions) {
+        p *= rotation;
+    }
+    for (auto& n : normals) {
+        n *= rotation;
+    }
+}
+
+int TrackGenerator::findCarIndex(const std::vector<cdouble>& positions,
+                                 double startOffset) {
+    const int nPoints = static_cast<int>(positions.size());
+    if (nPoints == 0) {
+        return 0;
+    }
+
+    const double totalLength = computeTrackLength(positions);
+    const double targetOffset = std::min(startOffset, totalLength);
+
+    int current = 0;
+    double accumulated = 0.0;
+    std::vector<bool> visited(static_cast<std::size_t>(nPoints), false);
+
+    while (accumulated < targetOffset) {
+        const int prev = (current - 1 + nPoints) % nPoints;
+        accumulated += std::abs(positions[current] - positions[prev]);
+        current = prev;
+        if (visited[static_cast<std::size_t>(current)]) {
+            break;
+        }
+        visited[static_cast<std::size_t>(current)] = true;
+        if (accumulated >= totalLength) {
+            break;
+        }
+    }
+    return current;
+}
+
+void TrackGenerator::applyTransform(std::vector<cdouble>& points,
+                                    const cdouble& translation,
+                                    const cdouble& rotation) {
+    for (auto& point : points) {
+        point = (point - translation) * rotation;
+    }
+}
+
 std::vector<cdouble> TrackGenerator::placeCones(const std::vector<cdouble>& points,
                                                 const std::vector<double>& radii,
                                                 int side,
@@ -144,16 +312,20 @@ TrackResult TrackGenerator::generateTrack(const PathConfig& config, const PathRe
     double coneSpacingBias = config.coneSpacingBias;
     double minCornerRadius = config.minCornerRadius;
 
-    std::vector<cdouble> pointsC(nPoints); std::vector<cdouble> normalsC(nPoints);
+    std::vector<cdouble> pointsC(nPoints);
+    std::vector<cdouble> normalsC(nPoints);
     for (int i = 0; i < nPoints; ++i) {
         pointsC[i] = cdouble(path.points[i].x(), path.points[i].y());
         normalsC[i] = cdouble(path.normals[i].x(), path.normals[i].y());
     }
 
+    std::vector<double> radii(path.cornerRadii.begin(), path.cornerRadii.end());
+    pickStartingPoint(pointsC, normalsC, radii, config.startingStraightLength,
+                      config.startingStraightDownsample);
+
     auto leftPoints = addComplexArrays(pointsC, multiplyComplexArrayScalar(normalsC, trackWidth / 2.0));
     auto rightPoints = subtractComplexArrays(pointsC, multiplyComplexArrayScalar(normalsC, trackWidth / 2.0));
 
-    std::vector<double> radii(path.cornerRadii.begin(), path.cornerRadii.end());
     auto leftRadii = translateDoubleArray(radii, -trackWidth / 2.0);
     auto rightRadii = translateDoubleArray(radii, trackWidth / 2.0);
 
@@ -164,23 +336,39 @@ TrackResult TrackGenerator::generateTrack(const PathConfig& config, const PathRe
 
     std::vector<cdouble> startConesC;
     if (!leftConesC.empty() && !rightConesC.empty()) {
-        cdouble forward = (nPoints > 1) ? (pointsC[1] - pointsC[0]) : cdouble(1.0, 0.0);
-        double forwardMag = std::abs(forward);
-        if (forwardMag == 0.0) {
-            forward = cdouble(1.0, 0.0);
-            forwardMag = 1.0;
-        }
-        cdouble unitForward = forward / forwardMag;
-        cdouble offset = unitForward * (config.startingConeSpacing / 2.0);
-
-        cdouble leftStart = leftConesC.front();
-        cdouble rightStart = rightConesC.front();
+        const cdouble offset(config.startingConeSpacing / 2.0, 0.0);
+        const cdouble leftStart = leftConesC.front();
+        const cdouble rightStart = rightConesC.front();
         startConesC.push_back(leftStart + offset);
         startConesC.push_back(rightStart + offset);
         startConesC.push_back(leftStart - offset);
         startConesC.push_back(rightStart - offset);
+    }
 
+    const int carIndex = findCarIndex(pointsC, config.startingStraightLength);
+    const cdouble carTranslation = pointsC[carIndex];
+    cdouble carNormal = normalsC[carIndex];
+    if (std::abs(carNormal) == 0.0) {
+        carNormal = cdouble(0.0, 1.0);
+    }
+    const cdouble carRotation = cdouble(0.0, 1.0) / carNormal;
+
+    applyTransform(leftConesC, carTranslation, carRotation);
+    applyTransform(rightConesC, carTranslation, carRotation);
+    applyTransform(startConesC, carTranslation, carRotation);
+
+    if (!leftConesC.empty()) {
         leftConesC.erase(leftConesC.begin());
+    }
+    if (!rightConesC.empty()) {
+        rightConesC.erase(rightConesC.begin());
+    }
+
+    const double minStartClearance = std::max(config.startingConeSpacing, config.trackWidth);
+    if (leftConesC.size() > 1 && std::abs(leftConesC.front()) < minStartClearance) {
+        leftConesC.erase(leftConesC.begin());
+    }
+    if (rightConesC.size() > 1 && std::abs(rightConesC.front()) < minStartClearance) {
         rightConesC.erase(rightConesC.begin());
     }
 


### PR DESCRIPTION
## Summary
- align the track generator with the Python reference by rotating the start straight, positioning the car behind the start cones, and clearing space around the large cones
- add precise cone dimensions/constants and update the 2D renderer to draw vertical stripes with type-specific heights
- overhaul the stereo renderer cone mesh and shaders to approximate the WEMAS profile and carry per-instance colours/stripe data from the simulation world

## Testing
- ./build.sh *(fails: missing Eigen3Config.cmake in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_6906928969608324b020f35599abfff8