### PR TITLE
Add interactive mission selection before simulator startup

### DIFF
--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -12,6 +12,7 @@
 #include "PathConfig.hpp"
 #include "PathGenerator.hpp"
 #include "TrackGenerator.hpp"
+#include "sim/mission_descriptor.hpp"
 
 enum class ConeType {
     Start,
@@ -31,7 +32,7 @@ public:
     World() = default;
 
     // Initialize the world with vehicle parameters and generate track.
-    void init(const char* yamlFilePath);
+    void init(const char* yamlFilePath, fsai::sim::MissionDescriptor mission);
 
     // Update simulation by dt seconds.
     void update(double dt);
@@ -94,6 +95,8 @@ public:
     bool hasSvcuCommand() const { return hasSvcuCommand_; }
     const DynamicBicycle& model() const { return carModel; }
 
+    const fsai::sim::MissionDescriptor& mission() const { return mission_; }
+
 private:
     void moveNextCheckpointToLast();
     void reset();
@@ -130,5 +133,6 @@ private:
     double deltaTime{0.0};
     double totalDistance{0.0};
     int lapCount{0};
+    fsai::sim::MissionDescriptor mission_{};
 };
 

--- a/sim/include/sim/mission_descriptor.hpp
+++ b/sim/include/sim/mission_descriptor.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+namespace fsai::sim {
+
+enum class MissionType {
+  kAcceleration,
+  kSkidpad,
+  kAutocross,
+  kTrackdrive,
+};
+
+struct MissionDescriptor {
+  MissionType type{MissionType::kAutocross};
+  std::string name{"Autocross"};
+  std::string short_name{"autocross"};
+};
+
+}  // namespace fsai::sim
+

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <utility>
 #include "fsai_clock.h"
 #include "World.hpp"
 #include "sim/cone_constants.hpp"
@@ -63,7 +64,8 @@ void World::setSvcuCommand(float throttle, float brake, float steer) {
     hasSvcuCommand_ = true;
 }
 
-void World::init(const char* yamlFilePath) {
+void World::init(const char* yamlFilePath, fsai::sim::MissionDescriptor mission) {
+    mission_ = std::move(mission);
     // Generate track data
     PathConfig pathConfig;
     int nPoints = pathConfig.resolution;


### PR DESCRIPTION
## Summary
- add an interactive mission selection prompt with a --mission override for scripted runs
- introduce a mission descriptor structure and pass the selected mission into world setup
- store the mission choice for later use by the simulation components

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691232dd60908324a76dc4783243401b)