### PR TITLE
Publish mission metadata through AI-to-VCU adapter

### DIFF
--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -1575,6 +1575,7 @@ int main(int argc, char* argv[]) {
   adapter_cfg.brake_rear_bias = brake_rear_bias;
   adapter_cfg.max_speed_kph =
       static_cast<float>(vehicle_param.input_ranges.vel.max * 3.6);
+  adapter_cfg.mission_descriptor = mission_definition.descriptor;
   fsai::control::runtime::Ai2VcuAdapter ai2vcu_adapter(adapter_cfg);
 
   fsai::control::runtime::Ai2VcuCommandSet last_ai2vcu_commands{};
@@ -1691,6 +1692,18 @@ int main(int argc, char* argv[]) {
       adapter_telemetry.measured_speed_mps = measured_speed_mps;
       adapter_telemetry.lap_counter = static_cast<uint8_t>(
           std::clamp(world.completedLaps(), 0, 15));
+      adapter_telemetry.mission_laps_completed = static_cast<uint16_t>(
+          std::min<std::size_t>(mission_state.completed_laps(),
+                                 std::numeric_limits<uint16_t>::max()));
+      adapter_telemetry.mission_laps_target = static_cast<uint16_t>(
+          std::min<std::size_t>(mission_state.target_laps(),
+                                 std::numeric_limits<uint16_t>::max()));
+      adapter_telemetry.mission_selected = true;
+      adapter_telemetry.mission_running =
+          mission_state.run_status() == fsai::sim::MissionRunStatus::kRunning;
+      adapter_telemetry.mission_finished =
+          mission_state.run_status() == fsai::sim::MissionRunStatus::kCompleted ||
+          mission_state.stop_commanded();
       const auto total_cones = world.getLeftCones().size() +
                                world.getRightCones().size() +
                                world.getStartCones().size();

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -1688,6 +1688,7 @@ int main(int argc, char* argv[]) {
     control_cmd.t_ns = now_ns;
 
     if (now_ns - last_ai2vcu_tx_ns >= ai2vcu_period_ns) {
+      const auto& mission_state = world.missionRuntime();
       fsai::control::runtime::Ai2VcuAdapter::AdapterTelemetry adapter_telemetry{};
       adapter_telemetry.measured_speed_mps = measured_speed_mps;
       adapter_telemetry.lap_counter = static_cast<uint8_t>(

--- a/sim/svcu/adsdv_dbc.cpp
+++ b/sim/svcu/adsdv_dbc.cpp
@@ -87,8 +87,10 @@ bool decode_ai2vcu_status(const can_frame& frame, Ai2VcuStatus& out) {
   std::memset(&out, 0, sizeof(out));
   out.handshake = read_bits_le(frame.data, 0, 1) != 0;
   out.estop_request = read_bits_le(frame.data, 8, 1) != 0;
+  out.mission_complete = read_bits_le(frame.data, 9, 1) != 0;
   out.mission_status = static_cast<MissionStatus>(read_bits_le(frame.data, 12, 2));
   out.direction_request = static_cast<DirectionRequest>(read_bits_le(frame.data, 14, 2));
+  out.mission_id = static_cast<uint8_t>(read_bits_le(frame.data, 20, 4));
   out.lap_counter = static_cast<uint8_t>(read_bits_le(frame.data, 16, 4));
   out.cones_count_actual = static_cast<uint8_t>(read_bits_le(frame.data, 24, 8));
   out.cones_count_all = static_cast<uint16_t>(read_bits_le(frame.data, 32, 16));
@@ -250,9 +252,11 @@ can_frame encode_ai2vcu_status(const Ai2VcuStatus& status) {
 
   write_bits_le(frame.data, 0, 1, status.handshake ? 1u : 0u);
   write_bits_le(frame.data, 8, 1, status.estop_request ? 1u : 0u);
+  write_bits_le(frame.data, 9, 1, status.mission_complete ? 1u : 0u);
   write_bits_le(frame.data, 12, 2, static_cast<uint32_t>(status.mission_status));
   write_bits_le(frame.data, 14, 2, static_cast<uint32_t>(status.direction_request));
   write_bits_le(frame.data, 16, 4, status.lap_counter);
+  write_bits_le(frame.data, 20, 4, clamp<uint32_t>(status.mission_id, 0u, 15u));
   write_bits_le(frame.data, 24, 8, status.cones_count_actual);
   write_bits_le(frame.data, 32, 16, status.cones_count_all);
   write_bits_le(frame.data, 48, 8, pack_u8(status.veh_speed_actual_kph, 1.0, 0.0, 255.0));

--- a/sim/svcu/adsdv_dbc.hpp
+++ b/sim/svcu/adsdv_dbc.hpp
@@ -53,8 +53,10 @@ enum class EbsStatus : uint8_t { kUnavailable = 1, kArmed = 2, kTriggered = 3 };
 struct Ai2VcuStatus {
   bool handshake{false};
   bool estop_request{false};
+  bool mission_complete{false};
   MissionStatus mission_status{MissionStatus::kNotSelected};
   DirectionRequest direction_request{DirectionRequest::kNeutral};
+  uint8_t mission_id{0};
   uint8_t lap_counter{0};
   uint8_t cones_count_actual{0};
   uint16_t cones_count_all{0};


### PR DESCRIPTION
## Summary
- inject the mission descriptor into the AI-to-VCU adapter so it emits mission IDs and derives status transitions from simulation telemetry
- extend the AI-to-VCU status CAN schema and SVCU runner so missions halt on completion and reset cleanly for the next run
- add a mission status packaging test that exercises the new telemetry flow

## Testing
- bash build.sh *(fails: missing Eigen3 package in build environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691366c1740c8324a638725f1f2f6adc)