### PR TITLE
Improve gate crossing detection and add regression test

### DIFF
--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -39,7 +39,7 @@ public:
     void update(double dt);
 
     // Detect collisions with checkpoints and cones. Returns false if a reset occurred.
-    bool detectCollisions();
+    bool detectCollisions(bool crossedGate);
 
     // Output telemetry information.
     void telemetry() const;
@@ -103,6 +103,7 @@ public:
     const fsai::sim::MissionDefinition& mission() const { return mission_; }
 
 private:
+    friend class WorldTestHelper;
     void moveNextCheckpointToLast();
     void reset();
     void configureTrackState(const fsai::sim::TrackData& track);
@@ -115,6 +116,7 @@ private:
                           Eigen::Vector3d::Zero()};
     VehicleInput carInput{0.0, 0.0, 0.0};
     Transform carTransform{};
+    Vector2 prevCarPos_{0.0f, 0.0f};
 
     std::vector<Vector3> checkpointPositions{};
     std::vector<Cone> startCones{};
@@ -153,5 +155,6 @@ private:
     void configureMissionRuntime();
     void updateStraightLineProgress();
     void handleMissionCompletion();
+    bool crossesCurrentGate(const Vector2& previous, const Vector2& current) const;
 };
 

--- a/sim/tests/WorldGateTest.cpp
+++ b/sim/tests/WorldGateTest.cpp
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "World.hpp"
 

--- a/sim/tests/WorldGateTest.cpp
+++ b/sim/tests/WorldGateTest.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include "World.hpp"
+
+class WorldTestHelper {
+public:
+    static void ConfigureSimpleGate(World& world) {
+        world.checkpointPositions.clear();
+        world.checkpointPositions.push_back(Vector3{0.0f, 0.0f, 5.0f});
+        world.checkpointPositions.push_back(Vector3{0.0f, 0.0f, 15.0f});
+
+        world.leftCones.clear();
+        Cone left{};
+        left.position = Vector3{-1.0f, 0.0f, 5.0f};
+        left.radius = 0.25f;
+        left.mass = 1.0f;
+        left.type = ConeType::Left;
+        world.leftCones.push_back(left);
+
+        world.rightCones.clear();
+        Cone right{};
+        right.position = Vector3{1.0f, 0.0f, 5.0f};
+        right.radius = 0.25f;
+        right.mass = 1.0f;
+        right.type = ConeType::Right;
+        world.rightCones.push_back(right);
+
+        world.startCones.clear();
+        world.lastCheckpoint = Vector3{1000.0f, 0.0f, 1000.0f};
+        world.prevCarPos_ = Vector2{0.0f, 0.0f};
+        world.carTransform.position.x = 0.0f;
+        world.carTransform.position.y = 0.5f;
+        world.carTransform.position.z = 0.0f;
+        world.insideLastCheckpoint_ = false;
+    }
+
+    static std::vector<Vector3> Checkpoints(const World& world) {
+        return world.checkpointPositions;
+    }
+
+    static void SetPrev(World& world, Vector2 prev) {
+        world.prevCarPos_ = prev;
+    }
+
+    static void SetCarPosition(World& world, float x, float z) {
+        world.carTransform.position.x = x;
+        world.carTransform.position.z = z;
+    }
+
+    static bool CrossesGate(World& world, Vector2 prev, Vector2 curr) {
+        return world.crossesCurrentGate(prev, curr);
+    }
+};
+
+TEST(WorldGateTest, AdvancesCheckpointOnCrossing) {
+    World world;
+    WorldTestHelper::ConfigureSimpleGate(world);
+    const auto initial = WorldTestHelper::Checkpoints(world);
+
+    const Vector2 prev{0.0f, 4.0f};
+    const Vector2 curr{0.0f, 6.0f};
+    WorldTestHelper::SetPrev(world, prev);
+    WorldTestHelper::SetCarPosition(world, curr.x, curr.y);
+
+    const bool crossed = WorldTestHelper::CrossesGate(world, prev, curr);
+    EXPECT_TRUE(crossed);
+    EXPECT_TRUE(world.detectCollisions(crossed));
+
+    const auto after = WorldTestHelper::Checkpoints(world);
+    EXPECT_EQ(initial.size(), after.size());
+    EXPECT_EQ(initial[1].z, after[0].z);
+}
+
+TEST(WorldGateTest, GateIgnoresNonCrossingMotion) {
+    World world;
+    WorldTestHelper::ConfigureSimpleGate(world);
+    const auto initial = WorldTestHelper::Checkpoints(world);
+
+    const Vector2 prev{3.0f, 4.0f};
+    const Vector2 curr{3.0f, 6.0f};
+    WorldTestHelper::SetPrev(world, prev);
+    WorldTestHelper::SetCarPosition(world, curr.x, curr.y);
+
+    const bool crossed = WorldTestHelper::CrossesGate(world, prev, curr);
+    EXPECT_FALSE(crossed);
+    EXPECT_TRUE(world.detectCollisions(crossed));
+
+    const auto after = WorldTestHelper::Checkpoints(world);
+    EXPECT_EQ(initial[0].z, after[0].z);
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+

--- a/sim/tests/gtest/gtest.h
+++ b/sim/tests/gtest/gtest.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace testing {
+
+struct TestInfo {
+    std::string name;
+    void (*func)();
+};
+
+inline std::vector<TestInfo>& Registry() {
+    static std::vector<TestInfo> tests;
+    return tests;
+}
+
+struct TestRegistrar {
+    TestRegistrar(const char* suite, const char* name, void (*func)()) {
+        Registry().push_back({std::string(suite) + "." + name, func});
+    }
+};
+
+inline bool& FailureFlag() {
+    static bool flag = false;
+    return flag;
+}
+
+inline void ResetFailure() {
+    FailureFlag() = false;
+}
+
+inline void Fail() {
+    FailureFlag() = true;
+}
+
+inline bool CurrentTestFailed() {
+    return FailureFlag();
+}
+
+inline void LogFailure(const char* file, int line, const std::string& message) {
+    Fail();
+    std::cerr << file << ":" << line << " " << message << std::endl;
+}
+
+inline int InitGoogleTest(int*, char**) {
+    return 0;
+}
+
+inline int RunAllTests() {
+    int failed = 0;
+    for (const auto& test : Registry()) {
+        std::cout << "[ RUN      ] " << test.name << std::endl;
+        ResetFailure();
+        test.func();
+        if (CurrentTestFailed()) {
+            ++failed;
+            std::cout << "[  FAILED  ] " << test.name << std::endl;
+        } else {
+            std::cout << "[       OK ] " << test.name << std::endl;
+        }
+    }
+    return failed == 0 ? 0 : 1;
+}
+
+}  // namespace testing
+
+#define TEST(SuiteName, TestName)                                                          \
+    void SuiteName##_##TestName##_Test();                                                   \
+    static ::testing::TestRegistrar SuiteName##_##TestName##_registrar(                     \
+        #SuiteName, #TestName, &SuiteName##_##TestName##_Test);                             \
+    void SuiteName##_##TestName##_Test()
+
+#define EXPECT_TRUE(condition)                                                              \
+    do {                                                                                    \
+        if (!(condition)) {                                                                 \
+            ::testing::LogFailure(__FILE__, __LINE__,                                       \
+                                 std::string("Expected true: ") + #condition);             \
+        }                                                                                   \
+    } while (0)
+
+#define EXPECT_FALSE(condition)                                                             \
+    do {                                                                                    \
+        if (condition) {                                                                    \
+            ::testing::LogFailure(__FILE__, __LINE__,                                       \
+                                 std::string("Expected false: ") + #condition);            \
+        }                                                                                   \
+    } while (0)
+
+#define EXPECT_EQ(val1, val2)                                                               \
+    do {                                                                                    \
+        auto _expected = (val1);                                                            \
+        auto _actual = (val2);                                                              \
+        if (!(_expected == _actual)) {                                                      \
+            std::ostringstream _oss;                                                        \
+            _oss << "Expected equality of " << #val1 << " and " << #val2                  \
+                 << ", but got " << _expected << " and " << _actual;                     \
+            ::testing::LogFailure(__FILE__, __LINE__, _oss.str());                          \
+        }                                                                                   \
+    } while (0)
+
+#define RUN_ALL_TESTS() ::testing::RunAllTests()
+


### PR DESCRIPTION
## Summary
- track the previous car position so gate crossings can be evaluated using segment geometry instead of radial distance checks
- update the collision pipeline to use gate intersection logic and maintain the previous position after handling
- add a minimal gtest harness and regression test that verifies checkpoints advance only when the car crosses the gate

## Testing
- cmake -S . -B build *(fails: Eigen3Config.cmake not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913839e78648324a6693aa025dd7a7a)