### PR TITLE
Add collision segment detection and boundary collision test

### DIFF
--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -28,6 +28,14 @@ struct Cone {
     ConeType type{ConeType::Left};
 };
 
+struct CollisionSegment {
+    Vector2 start{0.0f, 0.0f};
+    Vector2 end{0.0f, 0.0f};
+    float radius{0.0f};
+    Vector2 boundsMin{0.0f, 0.0f};
+    Vector2 boundsMax{0.0f, 0.0f};
+};
+
 class World {
 public:
     World() = default;
@@ -122,6 +130,8 @@ private:
     std::vector<Cone> startCones{};
     std::vector<Cone> leftCones{};
     std::vector<Cone> rightCones{};
+    std::vector<CollisionSegment> gateSegments_{};
+    std::vector<CollisionSegment> boundarySegments_{};
     Vector3 lastCheckpoint{0.0f, 0.0f, 0.0f};
 
     WheelsInfo wheelsInfo_{WheelsInfo_default()};

--- a/sim/tests/WorldBoundaryCollisionTest.cpp
+++ b/sim/tests/WorldBoundaryCollisionTest.cpp
@@ -1,0 +1,42 @@
+#include "gtest/gtest.h"
+
+#include "WorldTestHelper.hpp"
+#include "sim/cone_constants.hpp"
+
+namespace {
+
+Transform MakeTransform(float x, float z) {
+    Transform t{};
+    t.position = Vector3{x, 0.0f, z};
+    t.yaw = 0.0f;
+    return t;
+}
+
+}  // namespace
+
+TEST(WorldBoundaryCollisionTest, LeftBoundaryTriggersReset) {
+    World world;
+
+    fsai::sim::TrackData track;
+    track.leftCones.push_back(MakeTransform(-1.0f, 0.0f));
+    track.leftCones.push_back(MakeTransform(-1.0f, 10.0f));
+    track.rightCones.push_back(MakeTransform(1.0f, 0.0f));
+    track.rightCones.push_back(MakeTransform(1.0f, 10.0f));
+    track.checkpoints.push_back(MakeTransform(0.0f, 0.0f));
+    track.checkpoints.push_back(MakeTransform(0.0f, 10.0f));
+
+    WorldTestHelper::SetCollisionRadius(world, 0.5f - fsai::sim::kSmallConeRadiusMeters);
+    WorldTestHelper::ConfigureTrack(world, track);
+    WorldTestHelper::SetPrev(world, Vector2{0.0f, 5.0f});
+    WorldTestHelper::SetCarPosition(world, -1.35f, 5.0f);
+    WorldTestHelper::SetCarHeight(world, 0.5f);
+    WorldTestHelper::SetInsideLastCheckpoint(world, false);
+
+    EXPECT_FALSE(world.detectCollisions(false));
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+

--- a/sim/tests/WorldGateTest.cpp
+++ b/sim/tests/WorldGateTest.cpp
@@ -1,56 +1,6 @@
 #include "gtest/gtest.h"
 
-#include "World.hpp"
-
-class WorldTestHelper {
-public:
-    static void ConfigureSimpleGate(World& world) {
-        world.checkpointPositions.clear();
-        world.checkpointPositions.push_back(Vector3{0.0f, 0.0f, 5.0f});
-        world.checkpointPositions.push_back(Vector3{0.0f, 0.0f, 15.0f});
-
-        world.leftCones.clear();
-        Cone left{};
-        left.position = Vector3{-1.0f, 0.0f, 5.0f};
-        left.radius = 0.25f;
-        left.mass = 1.0f;
-        left.type = ConeType::Left;
-        world.leftCones.push_back(left);
-
-        world.rightCones.clear();
-        Cone right{};
-        right.position = Vector3{1.0f, 0.0f, 5.0f};
-        right.radius = 0.25f;
-        right.mass = 1.0f;
-        right.type = ConeType::Right;
-        world.rightCones.push_back(right);
-
-        world.startCones.clear();
-        world.lastCheckpoint = Vector3{1000.0f, 0.0f, 1000.0f};
-        world.prevCarPos_ = Vector2{0.0f, 0.0f};
-        world.carTransform.position.x = 0.0f;
-        world.carTransform.position.y = 0.5f;
-        world.carTransform.position.z = 0.0f;
-        world.insideLastCheckpoint_ = false;
-    }
-
-    static std::vector<Vector3> Checkpoints(const World& world) {
-        return world.checkpointPositions;
-    }
-
-    static void SetPrev(World& world, Vector2 prev) {
-        world.prevCarPos_ = prev;
-    }
-
-    static void SetCarPosition(World& world, float x, float z) {
-        world.carTransform.position.x = x;
-        world.carTransform.position.z = z;
-    }
-
-    static bool CrossesGate(World& world, Vector2 prev, Vector2 curr) {
-        return world.crossesCurrentGate(prev, curr);
-    }
-};
+#include "WorldTestHelper.hpp"
 
 TEST(WorldGateTest, AdvancesCheckpointOnCrossing) {
     World world;

--- a/sim/tests/WorldTestHelper.hpp
+++ b/sim/tests/WorldTestHelper.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "World.hpp"
+#include "sim/mission/MissionDefinition.hpp"
+
+class WorldTestHelper {
+public:
+    static void ConfigureSimpleGate(World& world) {
+        world.checkpointPositions.clear();
+        world.checkpointPositions.push_back(Vector3{0.0f, 0.0f, 5.0f});
+        world.checkpointPositions.push_back(Vector3{0.0f, 0.0f, 15.0f});
+
+        world.leftCones.clear();
+        Cone left{};
+        left.position = Vector3{-1.0f, 0.0f, 5.0f};
+        left.radius = 0.25f;
+        left.mass = 1.0f;
+        left.type = ConeType::Left;
+        world.leftCones.push_back(left);
+
+        world.rightCones.clear();
+        Cone right{};
+        right.position = Vector3{1.0f, 0.0f, 5.0f};
+        right.radius = 0.25f;
+        right.mass = 1.0f;
+        right.type = ConeType::Right;
+        world.rightCones.push_back(right);
+
+        world.startCones.clear();
+        world.gateSegments_.clear();
+        world.boundarySegments_.clear();
+        world.lastCheckpoint = Vector3{1000.0f, 0.0f, 1000.0f};
+        world.prevCarPos_ = Vector2{0.0f, 0.0f};
+        world.carTransform.position.x = 0.0f;
+        world.carTransform.position.y = 0.5f;
+        world.carTransform.position.z = 0.0f;
+        world.insideLastCheckpoint_ = false;
+    }
+
+    static std::vector<Vector3> Checkpoints(const World& world) {
+        return world.checkpointPositions;
+    }
+
+    static void SetPrev(World& world, Vector2 prev) {
+        world.prevCarPos_ = prev;
+    }
+
+    static void SetCarPosition(World& world, float x, float z) {
+        world.carTransform.position.x = x;
+        world.carTransform.position.z = z;
+    }
+
+    static void SetCarHeight(World& world, float y) {
+        world.carTransform.position.y = y;
+    }
+
+    static bool CrossesGate(World& world, Vector2 prev, Vector2 curr) {
+        return world.crossesCurrentGate(prev, curr);
+    }
+
+    static void ConfigureTrack(World& world, const fsai::sim::TrackData& track) {
+        world.configureTrackState(track);
+    }
+
+    static void SetCollisionRadius(World& world, float radius) {
+        world.config.vehicleCollisionRadius = radius;
+    }
+
+    static void SetInsideLastCheckpoint(World& world, bool inside) {
+        world.insideLastCheckpoint_ = inside;
+    }
+};
+


### PR DESCRIPTION
## Summary
- add a reusable collision segment representation for gates and boundaries
- build gate and boundary segments during track configuration and check them in collision detection
- share a test helper and add a regression that resets when crossing the left boundary

## Testing
- cmake -S . -B build *(fails: Could not find a package configuration file provided by "Eigen3")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691392f3d7108324bcb8b8ad3b43ed11)