### PR TITLE
Refactor World to use injected vehicle dynamics

### DIFF
--- a/sim/tests/WorldBoundaryCollisionTest.cpp
+++ b/sim/tests/WorldBoundaryCollisionTest.cpp
@@ -16,6 +16,8 @@ Transform MakeTransform(float x, float z) {
 
 TEST(WorldBoundaryCollisionTest, LeftBoundaryTriggersReset) {
     World world;
+    VehicleDynamics dynamics;
+    world.setVehicleDynamics(dynamics);
 
     fsai::sim::TrackData track;
     track.leftCones.push_back(MakeTransform(-1.0f, 0.0f));
@@ -28,8 +30,8 @@ TEST(WorldBoundaryCollisionTest, LeftBoundaryTriggersReset) {
     WorldTestHelper::SetCollisionRadius(world, 0.5f - fsai::sim::kSmallConeRadiusMeters);
     WorldTestHelper::ConfigureTrack(world, track);
     WorldTestHelper::SetPrev(world, Vector2{0.0f, 5.0f});
-    WorldTestHelper::SetCarPosition(world, -1.35f, 5.0f);
-    WorldTestHelper::SetCarHeight(world, 0.5f);
+    WorldTestHelper::SetCarPosition(world, dynamics, -1.35f, 5.0f);
+    WorldTestHelper::SetCarHeight(world, dynamics, 0.5f);
     WorldTestHelper::SetInsideLastCheckpoint(world, false);
 
     EXPECT_FALSE(world.detectCollisions(false));

--- a/sim/tests/WorldGateTest.cpp
+++ b/sim/tests/WorldGateTest.cpp
@@ -4,13 +4,15 @@
 
 TEST(WorldGateTest, AdvancesCheckpointOnCrossing) {
     World world;
+    VehicleDynamics dynamics;
+    world.setVehicleDynamics(dynamics);
     WorldTestHelper::ConfigureSimpleGate(world);
     const auto initial = WorldTestHelper::Checkpoints(world);
 
     const Vector2 prev{0.0f, 4.0f};
     const Vector2 curr{0.0f, 6.0f};
     WorldTestHelper::SetPrev(world, prev);
-    WorldTestHelper::SetCarPosition(world, curr.x, curr.y);
+    WorldTestHelper::SetCarPosition(world, dynamics, curr.x, curr.y);
 
     const bool crossed = WorldTestHelper::CrossesGate(world, prev, curr);
     EXPECT_TRUE(crossed);
@@ -23,13 +25,15 @@ TEST(WorldGateTest, AdvancesCheckpointOnCrossing) {
 
 TEST(WorldGateTest, GateIgnoresNonCrossingMotion) {
     World world;
+    VehicleDynamics dynamics;
+    world.setVehicleDynamics(dynamics);
     WorldTestHelper::ConfigureSimpleGate(world);
     const auto initial = WorldTestHelper::Checkpoints(world);
 
     const Vector2 prev{3.0f, 4.0f};
     const Vector2 curr{3.0f, 6.0f};
     WorldTestHelper::SetPrev(world, prev);
-    WorldTestHelper::SetCarPosition(world, curr.x, curr.y);
+    WorldTestHelper::SetCarPosition(world, dynamics, curr.x, curr.y);
 
     const bool crossed = WorldTestHelper::CrossesGate(world, prev, curr);
     EXPECT_FALSE(crossed);

--- a/sim/tests/WorldTestHelper.hpp
+++ b/sim/tests/WorldTestHelper.hpp
@@ -44,13 +44,13 @@ public:
         world.prevCarPos_ = prev;
     }
 
-    static void SetCarPosition(World& world, float x, float z) {
-        SetVehiclePose(world, x, world.vehicleDynamics_.transform().position.y, z);
+    static void SetCarPosition(World& world, VehicleDynamics& dynamics, float x, float z) {
+        SetVehiclePose(world, dynamics, x, world.vehicleTransform().position.y, z);
     }
 
-    static void SetCarHeight(World& world, float y) {
-        const Transform& carTransform = world.vehicleDynamics_.transform();
-        SetVehiclePose(world, carTransform.position.x, y, carTransform.position.z);
+    static void SetCarHeight(World& world, VehicleDynamics& dynamics, float y) {
+        const Transform& carTransform = world.vehicleTransform();
+        SetVehiclePose(world, dynamics, carTransform.position.x, y, carTransform.position.z);
     }
 
     static bool CrossesGate(World& world, Vector2 prev, Vector2 curr) {
@@ -70,16 +70,16 @@ public:
     }
 
 private:
-    static void SetVehiclePose(World& world, float x, float y, float z) {
-        VehicleState state = world.vehicleDynamics_.state();
+    static void SetVehiclePose(World& world, VehicleDynamics& dynamics, float x, float y, float z) {
+        VehicleState state = dynamics.state();
         state.position = Eigen::Vector3d(static_cast<double>(x), static_cast<double>(z), state.position.z());
 
-        Transform transform = world.vehicleDynamics_.transform();
+        Transform transform = world.vehicleTransform();
         transform.position.x = x;
         transform.position.y = y;
         transform.position.z = z;
 
-        world.vehicleDynamics_.setState(state, transform);
+        dynamics.setState(state, transform);
     }
 };
 


### PR DESCRIPTION
## Summary
- inject non-owning VehicleDynamics into World and expose spawn/reset handshake
- step vehicle dynamics in fsai_run using the new World interface and reapply spawn state on resets
- update World test helpers and unit tests for the injected dynamics model

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692085f9febc832494c4a98c3ddc46c9)