### PR TITLE
Add IO bus facade and shared-memory fallback

### DIFF
--- a/io/include/io_bus.hpp
+++ b/io/include/io_bus.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <queue>
+#include <random>
+#include <utility>
+
+#include "common/types.h"
+#include "sim/svcu/link.hpp"
+
+namespace fsai::io {
+
+struct TelemetryNoiseConfig {
+  double steer_rad_stddev{0.0};
+  double axle_torque_stddev{0.0};
+  double wheel_rpm_stddev{0.0};
+  double brake_bar_stddev{0.0};
+  double imu_stddev{0.0};
+  double gps_speed_stddev{0.0};
+};
+
+class IoBus {
+ public:
+  virtual ~IoBus() = default;
+
+  virtual void set_noise_config(const TelemetryNoiseConfig& cfg) = 0;
+
+  virtual void publish_telemetry(const fsai::sim::svcu::TelemetryPacket& raw) = 0;
+  virtual std::optional<fsai::sim::svcu::TelemetryPacket> latest_raw_telemetry() = 0;
+  virtual std::optional<fsai::sim::svcu::TelemetryPacket> latest_noisy_telemetry() = 0;
+
+  virtual void push_command(const fsai::sim::svcu::CommandPacket& cmd) = 0;
+  virtual std::optional<fsai::sim::svcu::CommandPacket> latest_command() = 0;
+
+  virtual void publish_stereo_frame(const FsaiStereoFrame& frame) = 0;
+  virtual std::optional<FsaiStereoFrame> latest_stereo_frame() = 0;
+};
+
+class InProcessIoBus final : public IoBus {
+ public:
+  using TelemetrySink = std::function<void(const fsai::sim::svcu::TelemetryPacket&)>;
+  using StereoSink = std::function<void(const FsaiStereoFrame&)>;
+
+  InProcessIoBus();
+
+  void set_noise_config(const TelemetryNoiseConfig& cfg) override;
+  void set_telemetry_sink(TelemetrySink sink);
+  void set_stereo_sink(StereoSink sink);
+
+  void publish_telemetry(const fsai::sim::svcu::TelemetryPacket& raw) override;
+  std::optional<fsai::sim::svcu::TelemetryPacket> latest_raw_telemetry() override;
+  std::optional<fsai::sim::svcu::TelemetryPacket> latest_noisy_telemetry() override;
+
+  void push_command(const fsai::sim::svcu::CommandPacket& cmd) override;
+  std::optional<fsai::sim::svcu::CommandPacket> latest_command() override;
+
+  void publish_stereo_frame(const FsaiStereoFrame& frame) override;
+  std::optional<FsaiStereoFrame> latest_stereo_frame() override;
+
+ private:
+  fsai::sim::svcu::TelemetryPacket apply_noise(
+      const fsai::sim::svcu::TelemetryPacket& raw);
+
+  TelemetryNoiseConfig noise_{};
+  TelemetrySink telemetry_sink_{};
+  StereoSink stereo_sink_{};
+
+  std::optional<fsai::sim::svcu::TelemetryPacket> raw_telemetry_{};
+  std::optional<fsai::sim::svcu::TelemetryPacket> noisy_telemetry_{};
+  std::optional<fsai::sim::svcu::CommandPacket> latest_command_{};
+  std::optional<FsaiStereoFrame> last_frame_{};
+  std::mt19937 rng_;
+};
+
+}  // namespace fsai::io
+

--- a/sim/src/io_bus.cpp
+++ b/sim/src/io_bus.cpp
@@ -1,0 +1,86 @@
+#include "io_bus.hpp"
+
+#include <cmath>
+
+namespace fsai::io {
+namespace {
+
+double sample_noise(std::mt19937& rng, double stddev) {
+  if (stddev <= 0.0) {
+    return 0.0;
+  }
+  std::normal_distribution<double> dist(0.0, stddev);
+  return dist(rng);
+}
+
+}  // namespace
+
+InProcessIoBus::InProcessIoBus() : rng_(std::random_device{}()) {}
+
+void InProcessIoBus::set_noise_config(const TelemetryNoiseConfig& cfg) {
+  noise_ = cfg;
+}
+
+void InProcessIoBus::set_telemetry_sink(TelemetrySink sink) {
+  telemetry_sink_ = std::move(sink);
+}
+
+void InProcessIoBus::set_stereo_sink(StereoSink sink) { stereo_sink_ = std::move(sink); }
+
+fsai::sim::svcu::TelemetryPacket InProcessIoBus::apply_noise(
+    const fsai::sim::svcu::TelemetryPacket& raw) {
+  fsai::sim::svcu::TelemetryPacket noisy = raw;
+  noisy.steer_angle_rad += static_cast<float>(sample_noise(rng_, noise_.steer_rad_stddev));
+  noisy.front_axle_torque_nm +=
+      static_cast<float>(sample_noise(rng_, noise_.axle_torque_stddev));
+  noisy.rear_axle_torque_nm +=
+      static_cast<float>(sample_noise(rng_, noise_.axle_torque_stddev));
+  for (float& rpm : noisy.wheel_speed_rpm) {
+    rpm += static_cast<float>(sample_noise(rng_, noise_.wheel_rpm_stddev));
+  }
+  noisy.brake_pressure_front_bar +=
+      static_cast<float>(sample_noise(rng_, noise_.brake_bar_stddev));
+  noisy.brake_pressure_rear_bar +=
+      static_cast<float>(sample_noise(rng_, noise_.brake_bar_stddev));
+  noisy.imu_ax_mps2 += static_cast<float>(sample_noise(rng_, noise_.imu_stddev));
+  noisy.imu_ay_mps2 += static_cast<float>(sample_noise(rng_, noise_.imu_stddev));
+  noisy.imu_yaw_rate_rps += static_cast<float>(sample_noise(rng_, noise_.imu_stddev));
+  noisy.gps_speed_mps += static_cast<float>(sample_noise(rng_, noise_.gps_speed_stddev));
+  return noisy;
+}
+
+void InProcessIoBus::publish_telemetry(const fsai::sim::svcu::TelemetryPacket& raw) {
+  raw_telemetry_ = raw;
+  noisy_telemetry_ = apply_noise(raw);
+  if (telemetry_sink_) {
+    telemetry_sink_(*noisy_telemetry_);
+  }
+}
+
+std::optional<fsai::sim::svcu::TelemetryPacket> InProcessIoBus::latest_raw_telemetry() {
+  return raw_telemetry_;
+}
+
+std::optional<fsai::sim::svcu::TelemetryPacket> InProcessIoBus::latest_noisy_telemetry() {
+  return noisy_telemetry_;
+}
+
+void InProcessIoBus::push_command(const fsai::sim::svcu::CommandPacket& cmd) {
+  latest_command_ = cmd;
+}
+
+std::optional<fsai::sim::svcu::CommandPacket> InProcessIoBus::latest_command() {
+  return latest_command_;
+}
+
+void InProcessIoBus::publish_stereo_frame(const FsaiStereoFrame& frame) {
+  last_frame_ = frame;
+  if (stereo_sink_) {
+    stereo_sink_(frame);
+  }
+}
+
+std::optional<FsaiStereoFrame> InProcessIoBus::latest_stereo_frame() { return last_frame_; }
+
+}  // namespace fsai::io
+

--- a/sim/svcu/socketcan.cpp
+++ b/sim/svcu/socketcan.cpp
@@ -105,14 +105,6 @@ std::optional<can_frame> SocketCanLink::receive() {
 namespace fsai::sim::svcu {
 
 namespace {
-constexpr std::size_t kRingSize = 32;
-
-struct ShmRing {
-  size_t head{0};
-  size_t tail{0};
-  can_frame frames[kRingSize];
-};
-
 std::string make_shm_name(const std::string& iface) {
   std::string name = "/fsai_socketcan_" + iface;
   if (name.size() > 31) {
@@ -164,9 +156,9 @@ bool SocketCanLink::send(const can_frame& frame) {
     return false;
   }
   shared_->frames[shared_->head] = frame;
-  shared_->head = (shared_->head + 1) % kRingSize;
+  shared_->head = (shared_->head + 1) % kShmRingSize;
   if (shared_->head == shared_->tail) {
-    shared_->tail = (shared_->tail + 1) % kRingSize;
+    shared_->tail = (shared_->tail + 1) % kShmRingSize;
   }
   return true;
 }
@@ -176,7 +168,7 @@ std::optional<can_frame> SocketCanLink::receive() {
     return std::nullopt;
   }
   can_frame frame = shared_->frames[shared_->tail];
-  shared_->tail = (shared_->tail + 1) % kRingSize;
+  shared_->tail = (shared_->tail + 1) % kShmRingSize;
   return frame;
 }
 

--- a/sim/svcu/socketcan.cpp
+++ b/sim/svcu/socketcan.cpp
@@ -93,6 +93,95 @@ std::optional<can_frame> SocketCanLink::receive() {
 
 }  // namespace fsai::sim::svcu
 
+#elif defined(__APPLE__)
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <string>
+
+namespace fsai::sim::svcu {
+
+namespace {
+constexpr std::size_t kRingSize = 32;
+
+struct ShmRing {
+  size_t head{0};
+  size_t tail{0};
+  can_frame frames[kRingSize];
+};
+
+std::string make_shm_name(const std::string& iface) {
+  std::string name = "/fsai_socketcan_" + iface;
+  if (name.size() > 31) {
+    name.resize(31);
+  }
+  return name;
+}
+
+}  // namespace
+
+SocketCanLink::SocketCanLink() : fd_(-1), shared_(nullptr), created_(false) {}
+
+SocketCanLink::~SocketCanLink() { close(); }
+
+bool SocketCanLink::open(const std::string& iface, bool) {
+  close();
+  const std::string name = make_shm_name(iface);
+  fd_ = ::shm_open(name.c_str(), O_RDWR | O_CREAT, 0600);
+  if (fd_ < 0) {
+    return false;
+  }
+  created_ = (::ftruncate(fd_, sizeof(ShmRing)) == 0);
+  void* addr = ::mmap(nullptr, sizeof(ShmRing), PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+  if (addr == MAP_FAILED) {
+    ::close(fd_);
+    fd_ = -1;
+    return false;
+  }
+  shared_ = static_cast<ShmRing*>(addr);
+  if (created_) {
+    std::memset(shared_, 0, sizeof(ShmRing));
+  }
+  return true;
+}
+
+void SocketCanLink::close() {
+  if (shared_) {
+    ::munmap(shared_, sizeof(ShmRing));
+    shared_ = nullptr;
+  }
+  if (fd_ >= 0) {
+    ::close(fd_);
+    fd_ = -1;
+  }
+}
+
+bool SocketCanLink::send(const can_frame& frame) {
+  if (!shared_) {
+    return false;
+  }
+  shared_->frames[shared_->head] = frame;
+  shared_->head = (shared_->head + 1) % kRingSize;
+  if (shared_->head == shared_->tail) {
+    shared_->tail = (shared_->tail + 1) % kRingSize;
+  }
+  return true;
+}
+
+std::optional<can_frame> SocketCanLink::receive() {
+  if (!shared_ || shared_->tail == shared_->head) {
+    return std::nullopt;
+  }
+  can_frame frame = shared_->frames[shared_->tail];
+  shared_->tail = (shared_->tail + 1) % kRingSize;
+  return frame;
+}
+
+}  // namespace fsai::sim::svcu
+
 #else
 
 namespace fsai::sim::svcu {

--- a/sim/svcu/socketcan.hpp
+++ b/sim/svcu/socketcan.hpp
@@ -7,6 +7,10 @@
 
 namespace fsai::sim::svcu {
 
+#if defined(__APPLE__)
+struct ShmRing;
+#endif
+
 class SocketCanLink : public ICanLink {
  public:
   SocketCanLink();
@@ -21,10 +25,14 @@ class SocketCanLink : public ICanLink {
   bool send(const can_frame& frame) override;
   std::optional<can_frame> receive() override;
 
-  bool valid() const { return fd_ >= 0; }
+ bool valid() const { return fd_ >= 0; }
 
  private:
   int fd_;
+#if defined(__APPLE__)
+  struct ShmRing* shared_;
+  bool created_;
+#endif
 };
 
 }  // namespace fsai::sim::svcu

--- a/sim/svcu/socketcan.hpp
+++ b/sim/svcu/socketcan.hpp
@@ -2,13 +2,19 @@
 
 #include "can_link.hpp"
 
+#include <cstddef>
 #include <optional>
 #include <string>
 
 namespace fsai::sim::svcu {
 
 #if defined(__APPLE__)
-struct ShmRing;
+constexpr std::size_t kShmRingSize = 32;
+struct ShmRing {
+  std::size_t head{0};
+  std::size_t tail{0};
+  can_frame frames[kShmRingSize];
+};
 #endif
 
 class SocketCanLink : public ICanLink {


### PR DESCRIPTION
## Summary
- add an IoBus abstraction with an in-process implementation that injects telemetry noise and routes stereo frames
- update fsai_run wiring to publish telemetry/command data and stereo captures through the IO bus facade
- provide a macOS shared-memory backend for SocketCAN while keeping the Linux path unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920885a4218832494b512124a649df0)