### PR TITLE
Add user input interface and route keyboard events

### DIFF
--- a/sim/include/human/IUserInput.hpp
+++ b/sim/include/human/IUserInput.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <optional>
+
+#include "sim/mission/MissionDefinition.hpp"
+
+namespace human {
+
+class IUserInput {
+ public:
+  virtual ~IUserInput() = default;
+
+  virtual void PublishEmergencyStop() = 0;
+  virtual void PublishMissionOverride(
+      const fsai::sim::MissionDescriptor& mission) = 0;
+
+  virtual bool ConsumeEmergencyStop() = 0;
+  virtual std::optional<fsai::sim::MissionDescriptor> ConsumeMissionOverride() = 0;
+};
+
+}  // namespace human
+


### PR DESCRIPTION
## Summary
- add a reusable `human::IUserInput` interface for mission overrides and emergency stops
- store mission overrides via the interface and rework mission selection to consume it
- forward SDL keyboard shortcuts in `fsai_run.cpp` through the new interface so other frontends can replace the keyboard handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235c61eb7c832492cd402d45b3d6ee)