### PR TITLE
Add world configuration file and debug gating

### DIFF
--- a/configs/sim/world.yaml
+++ b/configs/sim/world.yaml
@@ -1,0 +1,24 @@
+debug:
+  debug_mode: true
+  public_ground_truth: true
+
+rendering:
+  show_cones: true
+  show_checkpoints: true
+  show_paths: true
+
+physics:
+  gate_collision_threshold: 1.75
+  vehicle_collision_radius: 0.386
+  lap_completion_threshold: 0.2
+
+controller:
+  speed_lookahead_sensitivity: 0.5
+  steering_lookahead_sensitivity: 0.0
+  acceleration_factor: 0.0019
+
+mission:
+  selected: autocross
+  target_laps: 10
+  allow_regeneration: true
+  track_source: random

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -265,6 +265,7 @@ constexpr double kBaseLatitudeDeg = 37.4275;
 constexpr double kBaseLongitudeDeg = -122.1697;
 constexpr double kMetersPerDegreeLat = 111111.0;
 constexpr const char* kDefaultSensorConfig = "configs/sim/sensors.yaml";
+constexpr const char* kDefaultWorldConfig = "configs/sim/world.yaml";
 
 
 template <size_t Capacity>
@@ -1582,6 +1583,23 @@ struct GpsSample {
   double speed_mps{0.0};
 };
 
+struct WorldRuntimeConfig {
+  bool debug_mode{true};
+  bool public_ground_truth{true};
+  bool render_cones{true};
+  bool render_checkpoints{true};
+  bool render_paths{true};
+  float collision_threshold{1.75f};
+  float vehicle_collision_radius{0.5f - fsai::sim::kSmallConeRadiusMeters};
+  float lap_completion_threshold{0.2f};
+  ControllerConfig controller{0.5f, 0.0f, 0.0019f};
+  std::optional<fsai::sim::MissionDescriptor> mission_override{};
+  std::optional<std::size_t> mission_target_laps{};
+  std::optional<bool> allow_regeneration{};
+  std::optional<fsai::sim::TrackSource> track_source_override{};
+  std::optional<std::filesystem::path> track_csv_override{};
+};
+
 SensorNoiseConfig LoadSensorNoiseConfig(const std::string& path) {
   SensorNoiseConfig cfg;
   try {
@@ -1643,6 +1661,71 @@ SensorNoiseConfig LoadSensorNoiseConfig(const std::string& path) {
     }
   } catch (const std::exception& e) {
     std::fprintf(stderr, "Failed to load sensor config '%s': %s\n", path.c_str(), e.what());
+  }
+  return cfg;
+}
+
+WorldRuntimeConfig LoadWorldRuntimeConfig(const std::string& path) {
+  WorldRuntimeConfig cfg;
+  try {
+    YAML::Node root = YAML::LoadFile(path);
+    if (auto debug = root["debug"]) {
+      cfg.debug_mode = debug["debug_mode"].as<bool>(cfg.debug_mode);
+      cfg.public_ground_truth = debug["public_ground_truth"].as<bool>(cfg.public_ground_truth);
+    }
+    if (auto rendering = root["rendering"]) {
+      cfg.render_cones = rendering["show_cones"].as<bool>(cfg.render_cones);
+      cfg.render_checkpoints = rendering["show_checkpoints"].as<bool>(cfg.render_checkpoints);
+      cfg.render_paths = rendering["show_paths"].as<bool>(cfg.render_paths);
+    }
+    if (auto physics = root["physics"]) {
+      cfg.collision_threshold = physics["gate_collision_threshold"].as<float>(cfg.collision_threshold);
+      cfg.vehicle_collision_radius = physics["vehicle_collision_radius"].as<float>(cfg.vehicle_collision_radius);
+      cfg.lap_completion_threshold = physics["lap_completion_threshold"].as<float>(cfg.lap_completion_threshold);
+    }
+    if (auto controller = root["controller"]) {
+      cfg.controller.speedLookAheadSensitivity =
+          controller["speed_lookahead_sensitivity"].as<float>(cfg.controller.speedLookAheadSensitivity);
+      cfg.controller.steeringLookAheadSensitivity =
+          controller["steering_lookahead_sensitivity"].as<float>(cfg.controller.steeringLookAheadSensitivity);
+      cfg.controller.accelerationFactor =
+          controller["acceleration_factor"].as<float>(cfg.controller.accelerationFactor);
+    }
+    if (auto mission = root["mission"]) {
+      if (auto selected = mission["selected"]) {
+        const auto parsed = ParseMissionDescriptor(selected.as<std::string>());
+        if (parsed.has_value()) {
+          cfg.mission_override = parsed;
+        } else {
+          fsai::sim::log::Logf(fsai::sim::log::Level::kWarning,
+                               "Unrecognized mission override '%s' in %s",
+                               selected.as<std::string>().c_str(), path.c_str());
+        }
+      }
+      if (auto laps = mission["target_laps"]) {
+        cfg.mission_target_laps = laps.as<std::size_t>();
+      }
+      if (auto regen = mission["allow_regeneration"]) {
+        cfg.allow_regeneration = regen.as<bool>();
+      }
+      if (auto track_src = mission["track_source"]) {
+        const auto source_text = ToLower(track_src.as<std::string>());
+        if (source_text == "csv") {
+          cfg.track_source_override = fsai::sim::TrackSource::kCsv;
+        } else if (source_text == "random") {
+          cfg.track_source_override = fsai::sim::TrackSource::kRandom;
+        } else {
+          fsai::sim::log::Logf(fsai::sim::log::Level::kWarning,
+                               "Unknown track_source '%s' in %s",
+                               source_text.c_str(), path.c_str());
+        }
+      }
+      if (auto track_csv = mission["track_csv"]) {
+        cfg.track_csv_override = MakeProjectRelativePath(track_csv.as<std::string>());
+      }
+    }
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "Failed to load world config '%s': %s\n", path.c_str(), e.what());
   }
   return cfg;
 }
@@ -1710,6 +1793,7 @@ int main(int argc, char* argv[]) {
   uint16_t command_port = kDefaultCommandPort;
   uint16_t telemetry_port = kDefaultTelemetryPort;
   std::string sensor_config_path = kDefaultSensorConfig;
+  std::string world_config_path = kDefaultWorldConfig;
   std::optional<bool> edge_preview_override;
   std::optional<bool> detection_preview_override;
 
@@ -1728,6 +1812,8 @@ int main(int argc, char* argv[]) {
       telemetry_port = parse_port(argv[++i], telemetry_port);
     } else if (arg == "--sensor-config" && i + 1 < argc) {
       sensor_config_path = argv[++i];
+    } else if (arg == "--world-config" && i + 1 < argc) {
+      world_config_path = argv[++i];
     } else if (arg == "--edge-preview") {
       edge_preview_override = true;
     } else if (arg == "--no-edge-preview") {
@@ -1753,7 +1839,7 @@ int main(int argc, char* argv[]) {
       fsai::sim::log::LogfToStdout(
           fsai::sim::log::Level::kInfo,
           "Usage: fsai_run [--dt seconds] [--can-if iface|udp:port] [--cmd-port p] "
-          "[--state-port p] [--sensor-config path] [--mission name] "
+          "[--state-port p] [--sensor-config path] [--world-config path] [--mission name] "
           "[--edge-preview|--no-edge-preview] [--detection-preview|--no-detection_preview]");
       return EXIT_SUCCESS;
     } else if (i == 1 && argc == 2) {
@@ -1785,13 +1871,33 @@ int main(int argc, char* argv[]) {
       dt, mode.c_str(), can_iface.c_str(), can_is_udp ? "udp" : "socketcan",
       command_port, telemetry_port);
 
+  const auto world_runtime_config =
+      LoadWorldRuntimeConfig(MakeProjectRelativePath(world_config_path).string());
+  if (world_runtime_config.mission_override.has_value()) {
+    user_input.PublishMissionOverride(*world_runtime_config.mission_override);
+  }
+
   const fsai::sim::MissionDescriptor mission =
       ResolveMissionSelection(user_input);
   fsai::sim::log::Logf(fsai::sim::log::Level::kInfo, "Mission: %s",
                        mission.name.c_str());
 
-  const fsai::sim::MissionDefinition mission_definition =
+  fsai::sim::MissionDefinition mission_definition =
       BuildMissionDefinition(mission);
+  if (world_runtime_config.track_source_override.has_value()) {
+    mission_definition.trackSource = *world_runtime_config.track_source_override;
+  }
+  if (world_runtime_config.track_csv_override.has_value()) {
+    mission_definition.track = fsai::sim::TrackData::FromTrackResult(
+        fsai::sim::LoadTrackFromCsv(*world_runtime_config.track_csv_override));
+    mission_definition.trackSource = fsai::sim::TrackSource::kCsv;
+  }
+  if (world_runtime_config.mission_target_laps.has_value()) {
+    mission_definition.targetLaps = *world_runtime_config.mission_target_laps;
+  }
+  if (world_runtime_config.allow_regeneration.has_value()) {
+    mission_definition.allowRegeneration = *world_runtime_config.allow_regeneration;
+  }
   const char* track_source =
       mission_definition.trackSource == fsai::sim::TrackSource::kCsv ? "CSV" : "Random";
   fsai::sim::log::Logf(fsai::sim::log::Level::kInfo,
@@ -1897,7 +2003,17 @@ int main(int argc, char* argv[]) {
   const VehicleParam vehicle_param = VehicleParam::loadFromFile(vehicle_config_path.c_str());
   VehicleDynamics vehicle_dynamics(vehicle_param);
   World world;
-  WorldConfig world_config{mission_definition};
+  WorldConfig world_config{};
+  world_config.mission = mission_definition;
+  world_config.debug.debug_mode = world_runtime_config.debug_mode;
+  world_config.debug.public_ground_truth = world_runtime_config.public_ground_truth;
+  world_config.debug.render_cones = world_runtime_config.render_cones;
+  world_config.debug.render_checkpoints = world_runtime_config.render_checkpoints;
+  world_config.debug.render_paths = world_runtime_config.render_paths;
+  world_config.collision.collisionThreshold = world_runtime_config.collision_threshold;
+  world_config.collision.vehicleCollisionRadius = world_runtime_config.vehicle_collision_radius;
+  world_config.collision.lapCompletionThreshold = world_runtime_config.lap_completion_threshold;
+  world_config.controller_defaults = world_runtime_config.controller;
   world.init(vehicle_dynamics, world_config);
   vehicle_dynamics.setState(world.vehicleSpawnState().state,
                             world.vehicleSpawnState().transform);
@@ -2278,9 +2394,9 @@ int main(int argc, char* argv[]) {
       adapter_telemetry.mission_finished =
           mission_state.run_status() == fsai::sim::MissionRunStatus::kCompleted ||
           mission_state.stop_commanded();
-      const auto total_cones = world.getLeftCones().size() +
-                               world.getRightCones().size() +
-                               world.getStartCones().size();
+      const auto total_cones = world.left_cones().size() +
+                               world.right_cones().size() +
+                               world.start_cones().size();
       if (total_cones > 0) {
         adapter_telemetry.cones_count_all = static_cast<uint16_t>(
             std::min<size_t>(total_cones, std::numeric_limits<uint16_t>::max()));
@@ -2740,61 +2856,64 @@ int main(int argc, char* argv[]) {
                                  transform.position.z, transform.yaw);
 
       cone_positions.clear();
-      const auto& left_cones = world.getLeftCones();
-      const auto& right_cones = world.getRightCones();
-      const auto& start_cones_for_render = world.getStartCones();
-      cone_positions.reserve(left_cones.size() + right_cones.size() +
-                             start_cones_for_render.size());
+      const bool render_cones = world.debug_mode() && world.render_cones();
+      if (render_cones) {
+        const auto& left_cones = world.getLeftCones();
+        const auto& right_cones = world.getRightCones();
+        const auto& start_cones_for_render = world.getStartCones();
+        cone_positions.reserve(left_cones.size() + right_cones.size() +
+                               start_cones_for_render.size());
 
-      const float color_scale = 1.0f / 255.0f;
-      auto makeColor = [color_scale](int r, int g, int b) {
-        return std::array<float, 3>{r * color_scale, g * color_scale,
-                                    b * color_scale};
-      };
+        const float color_scale = 1.0f / 255.0f;
+        auto makeColor = [color_scale](int r, int g, int b) {
+          return std::array<float, 3>{r * color_scale, g * color_scale,
+                                      b * color_scale};
+        };
 
-      const auto start_body = makeColor(255, 140, 0);
-      const auto start_stripe = makeColor(255, 255, 255);
-      const auto left_body = makeColor(255, 214, 0);
-      const auto left_stripe = makeColor(50, 50, 50);
-      const auto right_body = makeColor(0, 102, 204);
-      const auto right_stripe = makeColor(255, 255, 255);
+        const auto start_body = makeColor(255, 140, 0);
+        const auto start_stripe = makeColor(255, 255, 255);
+        const auto left_body = makeColor(255, 214, 0);
+        const auto left_stripe = makeColor(50, 50, 50);
+        const auto right_body = makeColor(0, 102, 204);
+        const auto right_stripe = makeColor(255, 255, 255);
 
-      auto appendCone = [&](const Cone& cone) {
-        fsai::io::camera::sim_stereo::SimConeInstance instance{};
-        instance.position =
-            {cone.position.x, cone.position.y, cone.position.z};
-        instance.base_width = cone.radius * 2.0f;
-        instance.height =
-            (cone.type == ConeType::Start) ? fsai::sim::kLargeConeHeightMeters
-                                           : fsai::sim::kSmallConeHeightMeters;
-        switch (cone.type) {
-          case ConeType::Start:
-            instance.body_color = start_body;
-            instance.stripe_color = start_stripe;
-            instance.stripe_count = 2;
-            break;
-          case ConeType::Left:
-            instance.body_color = left_body;
-            instance.stripe_color = left_stripe;
-            instance.stripe_count = 1;
-            break;
-          case ConeType::Right:
-            instance.body_color = right_body;
-            instance.stripe_color = right_stripe;
-            instance.stripe_count = 1;
-            break;
+        auto appendCone = [&](const Cone& cone) {
+          fsai::io::camera::sim_stereo::SimConeInstance instance{};
+          instance.position =
+              {cone.position.x, cone.position.y, cone.position.z};
+          instance.base_width = cone.radius * 2.0f;
+          instance.height =
+              (cone.type == ConeType::Start) ? fsai::sim::kLargeConeHeightMeters
+                                             : fsai::sim::kSmallConeHeightMeters;
+          switch (cone.type) {
+            case ConeType::Start:
+              instance.body_color = start_body;
+              instance.stripe_color = start_stripe;
+              instance.stripe_count = 2;
+              break;
+            case ConeType::Left:
+              instance.body_color = left_body;
+              instance.stripe_color = left_stripe;
+              instance.stripe_count = 1;
+              break;
+            case ConeType::Right:
+              instance.body_color = right_body;
+              instance.stripe_color = right_stripe;
+              instance.stripe_count = 1;
+              break;
+          }
+          cone_positions.push_back(instance);
+        };
+
+        for (const auto& cone : left_cones) {
+          appendCone(cone);
         }
-        cone_positions.push_back(instance);
-      };
-
-      for (const auto& cone : left_cones) {
-        appendCone(cone);
-      }
-      for (const auto& cone : right_cones) {
-        appendCone(cone);
-      }
-      for (const auto& cone : start_cones_for_render) {
-        appendCone(cone);
+        for (const auto& cone : right_cones) {
+          appendCone(cone);
+        }
+        for (const auto& cone : start_cones_for_render) {
+          appendCone(cone);
+        }
       }
       stereo_source->setCones(cone_positions);
       const FsaiStereoFrame& frame = stereo_source->capture(now_ns);

--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -5,6 +5,7 @@
 #include <Eigen/Dense>
 #include "types.h"
 #include "VehicleState.hpp"
+#include "sim/cone_constants.hpp"
 #include "sim/vehicle/VehicleDynamics.hpp"
 #include "Telemetry.hpp"
 #include "controller.prot.h"
@@ -40,6 +41,19 @@ struct CollisionSegment {
 
 struct WorldConfig {
     fsai::sim::MissionDefinition mission;
+    struct DebugSettings {
+        bool debug_mode{true};
+        bool public_ground_truth{true};
+        bool render_cones{true};
+        bool render_checkpoints{true};
+        bool render_paths{true};
+    } debug{};
+    struct CollisionConfig {
+        float collisionThreshold{1.75f};
+        float vehicleCollisionRadius{0.5f - fsai::sim::kSmallConeRadiusMeters};
+        float lapCompletionThreshold{0.2f};
+    } collision{};
+    ControllerConfig controller_defaults{0.5f, 0.0f, 0.0019f};
 };
 
 class World : public fsai::world::IWorldView {
@@ -67,19 +81,16 @@ public:
     std::vector<std::pair<Vector2, Vector2>> bestPathEdges {};
     std::vector<FsaiConeDet> coneDetections {};
 
-
     const VehicleState& vehicleState() const { return vehicleDynamics().state(); }
     const Transform& vehicleTransform() const { return vehicleDynamics().transform(); }
-    const std::vector<Vector3>& checkpointPositionsWorld() const {
-        return checkpointPositions;
-    }
+    const std::vector<Vector3>& checkpointPositionsWorld() const { return debugAccess(checkpointPositions); }
 
-    const std::vector<Cone>& getStartCones() const { return startCones; }
-    const std::vector<Cone>& getLeftCones() const { return leftCones; }
-    const std::vector<Cone>& getRightCones() const { return rightCones; }
-    const std::vector<Vector3>& getStartConePositions() const { return startConePositions_; }
-    const std::vector<Vector3>& getLeftConePositions() const { return leftConePositions_; }
-    const std::vector<Vector3>& getRightConePositions() const { return rightConePositions_; }
+    const std::vector<Cone>& getStartCones() const { return debugAccess(startCones); }
+    const std::vector<Cone>& getLeftCones() const { return debugAccess(leftCones); }
+    const std::vector<Cone>& getRightCones() const { return debugAccess(rightCones); }
+    const std::vector<Vector3>& getStartConePositions() const { return debugAccess(startConePositions_); }
+    const std::vector<Vector3>& getLeftConePositions() const { return debugAccess(leftConePositions_); }
+    const std::vector<Vector3>& getRightConePositions() const { return debugAccess(rightConePositions_); }
     const LookaheadIndices& lookahead() const { return lookaheadIndices; }
     const WheelsInfo& wheelsInfo() const { return vehicleDynamics().wheels_info(); }
     double lapTimeSeconds() const { return totalTime; }
@@ -98,6 +109,12 @@ public:
 
     const fsai::sim::MissionDefinition& mission() const { return mission_; }
 
+    bool debug_mode() const { return debugConfig_.debug_mode; }
+    bool public_ground_truth() const { return debugConfig_.public_ground_truth; }
+    bool render_cones() const { return debugConfig_.render_cones; }
+    bool render_checkpoints() const { return debugConfig_.render_checkpoints; }
+    bool render_paths() const { return debugConfig_.render_paths; }
+
     // IWorldView overrides
     const VehicleState& vehicle_state() const override { return vehicleDynamics().state(); }
     const Transform& vehicle_transform() const override { return vehicleDynamics().transform(); }
@@ -113,7 +130,7 @@ public:
     double time_step_seconds() const override { return deltaTime; }
     int lap_count() const override { return lapCount; }
     const std::vector<std::pair<Vector2, Vector2>>& best_path_edges() const override { return bestPathEdges; }
-    const std::vector<FsaiConeDet>& ground_truth_detections() const override { return coneDetections; }
+    const std::vector<FsaiConeDet>& ground_truth_detections() const override;
     bool vehicle_reset_pending() const override { return vehicleResetPending_; }
     void acknowledge_vehicle_reset(const Transform& appliedTransform) override {
         acknowledgeVehicleReset(appliedTransform);
@@ -188,5 +205,14 @@ private:
     void handleMissionCompletion();
     bool crossesCurrentGate(const Vector2& previous, const Vector2& current) const;
     const VehicleDynamics& vehicleDynamics() const;
+    template <typename T>
+    const T& debugAccess(const T& value) const {
+        if (!debugConfig_.debug_mode) {
+            throw std::runtime_error("Debug access requested when debug_mode is disabled");
+        }
+        return value;
+    }
+
+    WorldConfig::DebugSettings debugConfig_{};
 };
 


### PR DESCRIPTION
## Summary
- add a world configuration YAML describing debug visibility, rendering, physics, controller, and mission defaults
- load world settings into fsai_run to override mission selection and controller/collision parameters passed to the world
- guard world debug accessors and ground-truth exposure with configuration flags to control visibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692440a9a3d88324ab624b22f332a5d6)