### PR TITLE
Refactor world track setup into builder and skidpad strategy

### DIFF
--- a/sim/include/PhysicsDiagnostics.hpp
+++ b/sim/include/PhysicsDiagnostics.hpp
@@ -1,0 +1,136 @@
+#pragma once
+#include <cmath>
+#include <cstdio>
+
+// Small, header-only diagnostics for body/world consistency.
+namespace physdiag {
+
+// Sideslip angle beta (rad): angle between velocity vector and body x-axis.
+inline double beta(double vx, double vy) {
+  // atan2 handles vx~0 cleanly; beta is signed with y-left positive.
+  return std::atan2(vy, std::max(1e-9, vx));
+}
+
+// Heading of world velocity vector (rad, CCW), given world xdot, ydot.
+inline double vel_heading(double xdot_world, double ydot_world) {
+  return std::atan2(ydot_world, xdot_world);
+}
+
+// Wrap angle to [-pi, pi]
+inline double wrap_pi(double a) {
+  while (a >  M_PI) a -= 2.0*M_PI;
+  while (a < -M_PI) a += 2.0*M_PI;
+  return a;
+}
+
+// Compute world xdot, ydot from body vx, vy and yaw (CCW)
+inline void world_vel_from_body(double yaw, double vx, double vy,
+                                double& xdot, double& ydot) {
+  const double c = std::cos(yaw), s = std::sin(yaw);
+  xdot = c*vx - s*vy;
+  ydot = s*vx + c*vy;
+}
+
+// Soft alignment to kill spurious sideslip and yaw at low/medium speeds.
+// This bleeds vy and r toward 0 when steering is small and |beta| too large,
+// and also nudges yaw toward the instantaneous velocity heading if needed.
+struct AlignParams {
+  double v_low      = 0.3;   // [m/s] start heavy damping below this
+  double v_mid      = 4.0;   // [m/s] taper off by here
+  double beta_soft  = 15.0 * M_PI/180.0; // [rad] tolerate up to 15°
+  double beta_hard  = 35.0 * M_PI/180.0; // [rad] clamp above this
+  double steer_small= 7.0 * M_PI/180.0;  // [rad] “small steering”
+  double vy_gain_lo = 12.0;  // [1/s] vy damping at very low speed
+  double vy_gain_md = 4.0;   // [1/s] vy damping in mid band
+  double r_gain_lo  = 8.0;   // [1/s] yaw-rate damping at very low speed
+  double r_gain_md  = 3.0;   // [1/s]
+  double yaw_nudge  = 3.0;   // [1/s] nudge yaw toward velocity heading
+};
+
+struct AlignState {
+  // For optional logging counters if you want
+  int applied_count{0};
+};
+
+// Applies alignment; returns true if any correction applied.
+inline bool enforce_alignment(double dt,
+                              double yaw, double steer,
+                              double& vx, double& vy, double& r,
+                              AlignState& st,
+                              const AlignParams& P = AlignParams{}) {
+  const double v = std::hypot(vx, vy);
+  if (v < 1e-6) {
+    // At rest: kill tiny drift to avoid “spin in place”
+    vy *= std::exp(-P.vy_gain_lo * dt);
+    r  *= std::exp(-P.r_gain_lo  * dt);
+    st.applied_count++;
+    return true;
+  }
+
+  // Compute sideslip beta and velocity heading vs yaw
+  const double b = beta(vx, vy);
+
+  // speed weight in [0,1]: 1 at very low speed, 0 above v_mid
+  const double w_lo = (v <= P.v_low) ? 1.0 :
+                      (v >= P.v_mid) ? 0.0 :
+                      1.0 - (v - P.v_low) / std::max(1e-6, (P.v_mid - P.v_low));
+
+  // steering small?
+  const bool steer_small = std::abs(steer) <= P.steer_small;
+
+  // If steering is small, we shouldn’t hold large |beta|: bleed vy & r.
+  bool applied = false;
+  if (steer_small && (std::abs(b) > P.beta_soft)) {
+    // Hard clamp to avoid insane β that can arise from an early sign mistake
+    const double b_clamped = std::clamp(b, -P.beta_hard, P.beta_hard);
+
+    // Target vy consistent with allowed beta: vy_target = tan(b_allowed)*vx
+    const double vy_target = std::tan(b_clamped) * std::max(0.0, vx);
+
+    // Damping gains blend with speed
+    const double g_vy = w_lo*P.vy_gain_lo + (1.0 - w_lo)*P.vy_gain_md;
+    const double g_r  = w_lo*P.r_gain_lo  + (1.0 - w_lo)*P.r_gain_md;
+
+    // Exponential toward target/calm
+    const double a_vy = std::exp(-g_vy * dt);
+    const double a_r  = std::exp(-g_r  * dt);
+
+    vy = vy_target + (vy - vy_target) * a_vy;
+    r  = r * a_r;
+
+    applied = true;
+  }
+
+  // Secondary: if the *world* velocity heading disagrees strongly with yaw,
+  // nudge yaw toward it a bit (prevents “pointing left, moving straight” persistence).
+  double xdot, ydot;
+  world_vel_from_body(yaw, vx, vy, xdot, ydot);
+  const double hv = vel_heading(xdot, ydot);
+  const double d_yaw = wrap_pi(hv - yaw);
+
+  if (steer_small && w_lo > 0.15 && std::abs(d_yaw) > 10.0 * M_PI/180.0) {
+    const double a_yaw = std::exp(-P.yaw_nudge * w_lo * dt);
+    // Equivalent to yaw += (1 - a)*d_yaw in integrated form.
+    // Implement as a small correction to r so integrator remains consistent:
+    const double r_nudge = (1.0 - a_yaw) * d_yaw / std::max(1e-6, dt);
+    r += r_nudge;
+    applied = true;
+  }
+
+  if (applied) st.applied_count++;
+  return applied;
+}
+
+// Optional one-shot printf to verify signs the first few frames:
+inline void debug_print_once(int frame_idx,
+                             double yaw, double vx, double vy, double r) {
+  if (frame_idx < 50 && (frame_idx % 5 == 0)) {
+    double xdot, ydot; world_vel_from_body(yaw, vx, vy, xdot, ydot);
+    const double hv = vel_heading(xdot, ydot);
+    const double b  = beta(vx, vy);
+    std::printf("[dbg%02d] yaw=%.3f  v=(%.3f,%.3f)  r=%.3f  hv=%.3f  beta=%.3f  hv-yaw=%.3f\n",
+                frame_idx, yaw, vx, vy, r, hv, b, hv - yaw);
+  }
+}
+
+} // namespace physdiag

--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -12,14 +12,14 @@
 #include "controller.prot.h"
 #include "Transform.h"
 #include "Vector.h"
-#include "sim/track/PathConfig.hpp"
-#include "sim/track/PathGenerator.hpp"
-#include "sim/track/TrackGenerator.hpp"
-#include "sim/architecture/IWorldView.hpp"
-#include "sim/mission/MissionDefinition.hpp"
-#include "sim/MissionRuntimeState.hpp"
-#include "sim/world/TrackState.hpp"
-#include "sim/src/world/TrackBuilder.hpp"
+#include "PathConfig.hpp"
+#include "PathGenerator.hpp"
+#include "TrackGenerator.hpp"
+#include "IWorldView.hpp"
+#include "MissionDefinition.hpp"
+#include "MissionRuntimeState.hpp"
+#include "TrackState.hpp"
+#include "TrackBuilder.hpp"
 
 struct WorldConfig {
     fsai::sim::MissionDefinition mission;

--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <optional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 #include <Eigen/Dense>
 #include "types.h"
@@ -10,36 +12,22 @@
 #include "controller.prot.h"
 #include "Transform.h"
 #include "Vector.h"
-#include "PathConfig.hpp"
-#include "PathGenerator.hpp"
-#include "TrackGenerator.hpp"
+#include "sim/track/PathConfig.hpp"
+#include "sim/track/PathGenerator.hpp"
+#include "sim/track/TrackGenerator.hpp"
 #include "sim/architecture/IWorldView.hpp"
 #include "sim/mission/MissionDefinition.hpp"
 #include "sim/MissionRuntimeState.hpp"
-
-enum class ConeType {
-    Start,
-    Left,
-    Right,
-};
-
-struct Cone {
-    Vector3 position{0.0f, 0.0f, 0.0f};
-    float radius{0.0f};
-    float mass{0.0f};
-    ConeType type{ConeType::Left};
-};
-
-struct CollisionSegment {
-    Vector2 start{0.0f, 0.0f};
-    Vector2 end{0.0f, 0.0f};
-    float radius{0.0f};
-    Vector2 boundsMin{0.0f, 0.0f};
-    Vector2 boundsMax{0.0f, 0.0f};
-};
+#include "sim/world/TrackState.hpp"
+#include "sim/src/world/TrackBuilder.hpp"
 
 struct WorldConfig {
     fsai::sim::MissionDefinition mission;
+    PathConfig pathConfig{};
+
+    WorldConfig() = default;
+    explicit WorldConfig(fsai::sim::MissionDefinition missionDefinition)
+        : mission(std::move(missionDefinition)) {}
 };
 
 class World : public fsai::world::IWorldView {
@@ -136,9 +124,8 @@ private:
     friend class WorldTestHelper;
     void moveNextCheckpointToLast();
     void reset();
-    void configureTrackState(const fsai::sim::TrackData& track);
+    void configureTrackState(const TrackBuildResult& trackState);
     void initializeVehiclePose();
-    fsai::sim::TrackData generateRandomTrack() const;
 
     const VehicleDynamics* vehicleDynamics_{nullptr};
     VehicleSpawnState spawnState_{};
@@ -174,6 +161,9 @@ private:
     double deltaTime{0.0};
     double totalDistance{0.0};
     int lapCount{0};
+    TrackBuilder trackBuilder_{};
+    PathConfig pathConfig_{};
+    std::optional<TrackBuildResult> trackState_{};
     fsai::sim::MissionDefinition mission_{};
     fsai::sim::MissionRuntimeState missionState_{};
     bool insideLastCheckpoint_{false};

--- a/sim/include/sim/world/TrackState.hpp
+++ b/sim/include/sim/world/TrackState.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <vector>
+
+#include "Transform.h"
+#include "Vector.h"
+#include "sim/mission/MissionDefinition.hpp"
+
+enum class ConeType {
+    Start,
+    Left,
+    Right,
+};
+
+struct Cone {
+    Vector3 position{0.0f, 0.0f, 0.0f};
+    float radius{0.0f};
+    float mass{0.0f};
+    ConeType type{ConeType::Left};
+};
+
+struct CollisionSegment {
+    Vector2 start{0.0f, 0.0f};
+    Vector2 end{0.0f, 0.0f};
+    float radius{0.0f};
+    Vector2 boundsMin{0.0f, 0.0f};
+    Vector2 boundsMax{0.0f, 0.0f};
+};
+
+struct TrackBuildResult {
+    fsai::sim::TrackData track{};
+    std::vector<Vector3> checkpointPositions{};
+    std::vector<Cone> startCones{};
+    std::vector<Cone> leftCones{};
+    std::vector<Cone> rightCones{};
+    std::vector<Vector3> startConePositions{};
+    std::vector<Vector3> leftConePositions{};
+    std::vector<Vector3> rightConePositions{};
+    std::vector<CollisionSegment> gateSegments{};
+    std::vector<CollisionSegment> boundarySegments{};
+    Vector3 lastCheckpoint{0.0f, 0.0f, 0.0f};
+};
+

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -13,11 +13,6 @@
 
 namespace {
 
-using fsai::sim::kLargeConeMassKg;
-using fsai::sim::kLargeConeRadiusMeters;
-using fsai::sim::kSmallConeMassKg;
-using fsai::sim::kSmallConeRadiusMeters;
-
 struct Vec2d {
     double x{0.0};
     double y{0.0};
@@ -67,42 +62,6 @@ bool segmentsIntersect(const Vec2d& p1, const Vec2d& p2, const Vec2d& q1, const 
     }
 
     return false;
-}
-
-Vector3 transformToVector3(const Transform& t) {
-    return {t.position.x, t.position.y, t.position.z};
-}
-
-Cone makeCone(const Transform& t, ConeType type) {
-    Cone cone;
-    cone.position = transformToVector3(t);
-    cone.type = type;
-    switch (type) {
-        case ConeType::Start:
-            cone.radius = kLargeConeRadiusMeters;
-            cone.mass = kLargeConeMassKg;
-            break;
-        case ConeType::Left:
-        case ConeType::Right:
-            cone.radius = kSmallConeRadiusMeters;
-            cone.mass = kSmallConeMassKg;
-            break;
-    }
-    return cone;
-}
-
-CollisionSegment makeSegment(const Vector2& start, const Vector2& end, float radius) {
-    CollisionSegment segment{};
-    segment.start = start;
-    segment.end = end;
-    segment.radius = radius;
-    const float minX = std::min(start.x, end.x) - radius;
-    const float maxX = std::max(start.x, end.x) + radius;
-    const float minY = std::min(start.y, end.y) - radius;
-    const float maxY = std::max(start.y, end.y) + radius;
-    segment.boundsMin = Vector2{minX, minY};
-    segment.boundsMax = Vector2{maxX, maxY};
-    return segment;
 }
 
 float distanceSquaredToSegment(const Vector2& point, const CollisionSegment& segment) {
@@ -184,21 +143,16 @@ void World::acknowledgeVehicleReset(const Transform& appliedTransform) {
 void World::init(const VehicleDynamics& vehicleDynamics, const WorldConfig& worldConfig) {
     setVehicleDynamics(vehicleDynamics);
     mission_ = worldConfig.mission;
-
-    if (mission_.trackSource == fsai::sim::TrackSource::kRandom &&
-        mission_.track.checkpoints.empty()) {
-        mission_.track = generateRandomTrack();
-    }
-
-    if (mission_.track.checkpoints.empty()) {
-        throw std::runtime_error("MissionDefinition did not provide any checkpoints");
-    }
+    pathConfig_ = worldConfig.pathConfig;
 
     this->config.collisionThreshold = 1.75f;
-    this->config.vehicleCollisionRadius = 0.5f - kSmallConeRadiusMeters;
+    this->config.vehicleCollisionRadius = 0.5f - fsai::sim::kSmallConeRadiusMeters;
     this->config.lapCompletionThreshold = 0.2f;
 
-    configureTrackState(mission_.track);
+    trackState_ = trackBuilder_.Build(mission_, pathConfig_, this->config.vehicleCollisionRadius);
+    mission_.track = trackState_->track;
+
+    configureTrackState(*trackState_);
     configureMissionRuntime();
 
     totalTime = 0.0;
@@ -367,171 +321,17 @@ void World::telemetry() const {
                      missionState_);
 }
 
-// Add this debug code to World::configureTrackState() in World.cpp
-// Place it right after loading the cones from track data
-
-void World::configureTrackState(const fsai::sim::TrackData& track) {
-    checkpointPositions.clear();
-    startCones.clear();
-    leftCones.clear();
-    rightCones.clear();
-    startConePositions_.clear();
-    leftConePositions_.clear();
-    rightConePositions_.clear();
-    gateSegments_.clear();
-    boundarySegments_.clear();
-
-    // Load checkpoints
-    for (const auto& cp : track.checkpoints)
-        checkpointPositions.push_back(transformToVector3(cp));
-
-    // Load cones
-    for (const auto& sc : track.startCones)
-        startCones.push_back(makeCone(sc, ConeType::Start));
-
-    for (const auto& lc : track.leftCones)
-        leftCones.push_back(makeCone(lc, ConeType::Left));
-
-    for (const auto& rc : track.rightCones)
-        rightCones.push_back(makeCone(rc, ConeType::Right));
-
-    bool isSkidpad = (mission_.descriptor.type == fsai::sim::MissionType::kSkidpad);
-
-    // =========================================================================
-    // DEBUG: Print orange cone positions
-    // =========================================================================
-    // Add this to World::configureTrackState() in the skidpad section
-    if (isSkidpad)
-    {
-        // Keep existing orange cones (the 4 big ones at top)
-        // Now ADD corridor cones (entrance/exit) as orange
-        
-        // Circle centers based on your data:
-        // Left circle: center around X=-9.25, Z=0
-        // Right circle: center around X=9.25, Z=0
-        const double leftCircleCenterX = -9.25;
-        const double rightCircleCenterX = 9.25;
-        const double circleCenterZ = 0.0;
-        const double circleRadius = 9.0; // Approximate radius from data
-        const double corridorMargin = 2.5; // Distance outside circle to consider "corridor"
-        
-        auto moveCorridorConesToOrange = [&](std::vector<Cone>& list) {
-            std::vector<Cone> keep;
-            for (auto& c : list) {
-                // Calculate distance from both circle centers
-                double distLeft = std::hypot(c.position.x - leftCircleCenterX, 
-                                            c.position.z - circleCenterZ);
-                double distRight = std::hypot(c.position.x - rightCircleCenterX, 
-                                            c.position.z - circleCenterZ);
-                
-                // If cone is NOT part of either circle (too far from both centers)
-                // then it's a corridor cone
-                bool isCorridorCone = (distLeft > circleRadius + corridorMargin) && 
-                                    (distRight > circleRadius + corridorMargin);
-                
-                if (isCorridorCone) {
-                    c.type = ConeType::Start;  // Make it ORANGE
-                    startCones.push_back(c);
-                } else {
-                    keep.push_back(c);
-                }
-            }
-            list = keep;
-        };
-        
-        moveCorridorConesToOrange(leftCones);
-        moveCorridorConesToOrange(rightCones);
-        
-        // Sort orange cones by Z so entrance (bottom) comes first
-        std::sort(startCones.begin(), startCones.end(), 
-                [](const Cone& a, const Cone& b) { 
-                    return a.position.z < b.position.z; 
-                });
-        
-        std::printf("After processing: Total orange cones = %zu\n", startCones.size());
-        
-        // Mirror the entire track along Z axis (flip upside down)
-        // So entrance moves from top to bottom
-        auto flipZ = [](std::vector<Cone>& cones) {
-            for (auto& c : cones) {
-                c.position.z = -c.position.z;
-            }
-        };
-        
-        flipZ(startCones);
-        flipZ(leftCones);
-        flipZ(rightCones);
-        
-        // Also flip checkpoints
-        for (auto& cp : checkpointPositions) {
-            cp.z = -cp.z;
-        }
-        
-        std::printf("Track flipped: entrance now at bottom (negative Z)\n");
-        
-        // Swap blue and yellow cones
-        std::swap(leftCones, rightCones);
-
-        std::printf("Blue and yellow cones swapped\n");
-    }
-    // =========================================================================
-
-    auto rebuildConePositions = [&]() {
-        startConePositions_.clear();
-        leftConePositions_.clear();
-        rightConePositions_.clear();
-        startConePositions_.reserve(startCones.size());
-        leftConePositions_.reserve(leftCones.size());
-        rightConePositions_.reserve(rightCones.size());
-        for (const auto& cone : startCones) {
-            startConePositions_.push_back(cone.position);
-        }
-        for (const auto& cone : leftCones) {
-            leftConePositions_.push_back(cone.position);
-        }
-        for (const auto& cone : rightCones) {
-            rightConePositions_.push_back(cone.position);
-        }
-    };
-
-    rebuildConePositions();
-
-    // Rest of your original code continues here...
-    if (!leftCones.empty() && !rightCones.empty()) {
-        const std::size_t gateCount = std::min(leftCones.size(), rightCones.size());
-        gateSegments_.reserve(gateCount);
-        for (std::size_t i = 0; i < gateCount; ++i) {
-            Vector2 left{leftCones[i].position.x, leftCones[i].position.z};
-            Vector2 right{rightCones[i].position.x, rightCones[i].position.z};
-            gateSegments_.push_back(makeSegment(left, right, config.vehicleCollisionRadius));
-        }
-    }
-
-    auto appendBoundarySegments = [&](const std::vector<Cone>& cones) {
-        if (cones.size() < 2) return;
-
-        for (std::size_t i = 0; i + 1 < cones.size(); ++i) {
-            Vector2 s{cones[i].position.x, cones[i].position.z};
-            Vector2 e{cones[i+1].position.x, cones[i+1].position.z};
-            boundarySegments_.push_back(makeSegment(s, e, config.vehicleCollisionRadius));
-        }
-
-        // close loop
-        Vector2 s{cones.back().position.x, cones.back().position.z};
-        Vector2 e{cones.front().position.x, cones.front().position.z};
-        boundarySegments_.push_back(makeSegment(s, e, config.vehicleCollisionRadius));
-    };
-
-    if (!isSkidpad) {
-        appendBoundarySegments(leftCones);
-        appendBoundarySegments(rightCones);
-    }
-
-    // Update last checkpoint
-    if (!track.checkpoints.empty())
-        lastCheckpoint = transformToVector3(track.checkpoints.back());
-    else
-        lastCheckpoint = {0.0f, 0.0f, 0.0f};
+void World::configureTrackState(const TrackBuildResult& trackState) {
+    checkpointPositions = trackState.checkpointPositions;
+    startCones = trackState.startCones;
+    leftCones = trackState.leftCones;
+    rightCones = trackState.rightCones;
+    startConePositions_ = trackState.startConePositions;
+    leftConePositions_ = trackState.leftConePositions;
+    rightConePositions_ = trackState.rightConePositions;
+    gateSegments_ = trackState.gateSegments;
+    boundarySegments_ = trackState.boundarySegments;
+    lastCheckpoint = trackState.lastCheckpoint;
 }
 
 void World::configureMissionRuntime() {
@@ -694,16 +494,6 @@ const VehicleDynamics& World::vehicleDynamics() const {
     return *vehicleDynamics_;
 }
 
-fsai::sim::TrackData World::generateRandomTrack() const {
-    PathConfig pathConfig;
-    int nPoints = pathConfig.resolution;
-    PathGenerator pathGen(pathConfig);
-    PathResult path = pathGen.generatePath(nPoints);
-    TrackGenerator trackGen;
-    TrackResult track = trackGen.generateTrack(pathConfig, path);
-    return fsai::sim::TrackData::FromTrackResult(track);
-}
-
 void World::moveNextCheckpointToLast() {
     if (!checkpointPositions.empty()) {
         std::rotate(checkpointPositions.begin(), checkpointPositions.begin() + 1, checkpointPositions.end());
@@ -728,11 +518,20 @@ void World::reset() {
     if (mission_.allowRegeneration && regenTrack) {
         std::printf("Regenerating track due to cone collision.\n");
         if (mission_.trackSource == fsai::sim::TrackSource::kRandom) {
-            mission_.track = generateRandomTrack();
+            mission_.track = {};
         }
-        configureTrackState(mission_.track);
+        trackState_ = trackBuilder_.Build(mission_, pathConfig_, config.vehicleCollisionRadius);
+        mission_.track = trackState_->track;
     } else {
         std::printf("Resetting simulation without regenerating track.\n");
+        if (!trackState_) {
+            trackState_ = trackBuilder_.Build(mission_, pathConfig_, config.vehicleCollisionRadius);
+            mission_.track = trackState_->track;
+        }
+    }
+
+    if (trackState_) {
+        configureTrackState(*trackState_);
     }
 
     configureMissionRuntime();

--- a/sim/src/world/TrackBuilder.cpp
+++ b/sim/src/world/TrackBuilder.cpp
@@ -1,0 +1,171 @@
+#include "sim/src/world/TrackBuilder.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+#include "sim/cone_constants.hpp"
+#include "sim/src/world/tracks/SkidpadTrackStrategy.hpp"
+#include "sim/track/PathGenerator.hpp"
+#include "sim/track/TrackGenerator.hpp"
+
+namespace {
+
+using fsai::sim::kLargeConeMassKg;
+using fsai::sim::kLargeConeRadiusMeters;
+using fsai::sim::kSmallConeMassKg;
+using fsai::sim::kSmallConeRadiusMeters;
+
+Vector3 transformToVector3(const Transform& t) {
+    return {t.position.x, t.position.y, t.position.z};
+}
+
+Cone makeCone(const Transform& t, ConeType type) {
+    Cone cone;
+    cone.position = transformToVector3(t);
+    cone.type = type;
+    switch (type) {
+        case ConeType::Start:
+            cone.radius = kLargeConeRadiusMeters;
+            cone.mass = kLargeConeMassKg;
+            break;
+        case ConeType::Left:
+        case ConeType::Right:
+            cone.radius = kSmallConeRadiusMeters;
+            cone.mass = kSmallConeMassKg;
+            break;
+    }
+    return cone;
+}
+
+CollisionSegment makeSegment(const Vector2& start, const Vector2& end, float radius) {
+    CollisionSegment segment{};
+    segment.start = start;
+    segment.end = end;
+    segment.radius = radius;
+    const float minX = std::min(start.x, end.x) - radius;
+    const float maxX = std::max(start.x, end.x) + radius;
+    const float minY = std::min(start.y, end.y) - radius;
+    const float maxY = std::max(start.y, end.y) + radius;
+    segment.boundsMin = Vector2{minX, minY};
+    segment.boundsMax = Vector2{maxX, maxY};
+    return segment;
+}
+
+}  // namespace
+
+TrackBuildResult TrackBuilder::Build(const fsai::sim::MissionDefinition& mission,
+                                     const PathConfig& pathConfig,
+                                     float vehicleCollisionRadius) const {
+    fsai::sim::TrackData trackData = BuildTrackData(mission, pathConfig);
+
+    if (trackData.checkpoints.empty()) {
+        throw std::runtime_error("MissionDefinition did not provide any checkpoints");
+    }
+
+    const bool isSkidpad = mission.descriptor.type == fsai::sim::MissionType::kSkidpad;
+    const fsai::sim::TrackData processed = ApplyStrategies(mission, trackData);
+
+    return DeriveState(processed, vehicleCollisionRadius, isSkidpad);
+}
+
+fsai::sim::TrackData TrackBuilder::BuildTrackData(const fsai::sim::MissionDefinition& mission,
+                                                  const PathConfig& pathConfig) const {
+    if (mission.trackSource != fsai::sim::TrackSource::kRandom ||
+        !mission.track.checkpoints.empty()) {
+        return mission.track;
+    }
+
+    PathConfig config = pathConfig;
+    config.calculateResolutionAndLength();
+    const int nPoints = config.resolution;
+    PathGenerator pathGenerator(config);
+    const PathResult path = pathGenerator.generatePath(nPoints);
+    TrackGenerator trackGenerator;
+    const TrackResult track = trackGenerator.generateTrack(config, path);
+    return fsai::sim::TrackData::FromTrackResult(track);
+}
+
+fsai::sim::TrackData TrackBuilder::ApplyStrategies(const fsai::sim::MissionDefinition& mission,
+                                                   const fsai::sim::TrackData& track) const {
+    if (mission.descriptor.type == fsai::sim::MissionType::kSkidpad) {
+        fsai::world::tracks::SkidpadTrackStrategy strategy;
+        return strategy.Apply(track);
+    }
+
+    return track;
+}
+
+TrackBuildResult TrackBuilder::DeriveState(const fsai::sim::TrackData& track,
+                                           float vehicleCollisionRadius,
+                                           bool isSkidpad) const {
+    TrackBuildResult state;
+    state.track = track;
+    state.checkpointPositions.reserve(track.checkpoints.size());
+    for (const auto& checkpoint : track.checkpoints) {
+        state.checkpointPositions.push_back(transformToVector3(checkpoint));
+    }
+
+    state.startCones.reserve(track.startCones.size());
+    for (const auto& cone : track.startCones) {
+        state.startCones.push_back(makeCone(cone, ConeType::Start));
+    }
+
+    state.leftCones.reserve(track.leftCones.size());
+    for (const auto& cone : track.leftCones) {
+        state.leftCones.push_back(makeCone(cone, ConeType::Left));
+    }
+
+    state.rightCones.reserve(track.rightCones.size());
+    for (const auto& cone : track.rightCones) {
+        state.rightCones.push_back(makeCone(cone, ConeType::Right));
+    }
+
+    auto rebuildConePositions = [&](std::vector<Vector3>& positions, const std::vector<Cone>& cones) {
+        positions.clear();
+        positions.reserve(cones.size());
+        for (const auto& cone : cones) {
+            positions.push_back(cone.position);
+        }
+    };
+
+    rebuildConePositions(state.startConePositions, state.startCones);
+    rebuildConePositions(state.leftConePositions, state.leftCones);
+    rebuildConePositions(state.rightConePositions, state.rightCones);
+
+    if (!state.leftCones.empty() && !state.rightCones.empty()) {
+        const std::size_t gateCount = std::min(state.leftCones.size(), state.rightCones.size());
+        state.gateSegments.reserve(gateCount);
+        for (std::size_t i = 0; i < gateCount; ++i) {
+            const Vector2 left{state.leftCones[i].position.x, state.leftCones[i].position.z};
+            const Vector2 right{state.rightCones[i].position.x, state.rightCones[i].position.z};
+            state.gateSegments.push_back(makeSegment(left, right, vehicleCollisionRadius));
+        }
+    }
+
+    auto appendBoundarySegments = [&](const std::vector<Cone>& cones) {
+        if (cones.size() < 2) return;
+
+        for (std::size_t i = 0; i + 1 < cones.size(); ++i) {
+            const Vector2 start{cones[i].position.x, cones[i].position.z};
+            const Vector2 end{cones[i + 1].position.x, cones[i + 1].position.z};
+            state.boundarySegments.push_back(makeSegment(start, end, vehicleCollisionRadius));
+        }
+
+        const Vector2 loopStart{cones.back().position.x, cones.back().position.z};
+        const Vector2 loopEnd{cones.front().position.x, cones.front().position.z};
+        state.boundarySegments.push_back(makeSegment(loopStart, loopEnd, vehicleCollisionRadius));
+    };
+
+    if (!isSkidpad) {
+        appendBoundarySegments(state.leftCones);
+        appendBoundarySegments(state.rightCones);
+    }
+
+    if (!track.checkpoints.empty()) {
+        state.lastCheckpoint = transformToVector3(track.checkpoints.back());
+    }
+
+    return state;
+}
+

--- a/sim/src/world/TrackBuilder.cpp
+++ b/sim/src/world/TrackBuilder.cpp
@@ -1,13 +1,13 @@
-#include "sim/src/world/TrackBuilder.hpp"
+#include "TrackBuilder.hpp"
 
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
 
 #include "sim/cone_constants.hpp"
-#include "sim/src/world/tracks/SkidpadTrackStrategy.hpp"
-#include "sim/track/PathGenerator.hpp"
-#include "sim/track/TrackGenerator.hpp"
+#include "SkidpadTrackStrategy.hpp"
+#include "PathGenerator.hpp"
+#include "TrackGenerator.hpp"
 
 namespace {
 

--- a/sim/src/world/TrackBuilder.hpp
+++ b/sim/src/world/TrackBuilder.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "sim/mission/MissionDefinition.hpp"
+#include "sim/track/PathConfig.hpp"
+#include "sim/world/TrackState.hpp"
+
+class TrackBuilder {
+public:
+    TrackBuildResult Build(const fsai::sim::MissionDefinition& mission,
+                           const PathConfig& pathConfig,
+                           float vehicleCollisionRadius) const;
+
+private:
+    fsai::sim::TrackData BuildTrackData(const fsai::sim::MissionDefinition& mission,
+                                        const PathConfig& pathConfig) const;
+    fsai::sim::TrackData ApplyStrategies(const fsai::sim::MissionDefinition& mission,
+                                         const fsai::sim::TrackData& track) const;
+    TrackBuildResult DeriveState(const fsai::sim::TrackData& track,
+                                 float vehicleCollisionRadius,
+                                 bool isSkidpad) const;
+};
+

--- a/sim/src/world/tracks/SkidpadTrackStrategy.cpp
+++ b/sim/src/world/tracks/SkidpadTrackStrategy.cpp
@@ -1,4 +1,4 @@
-#include "sim/src/world/tracks/SkidpadTrackStrategy.hpp"
+#include "SkidpadTrackStrategy.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/sim/src/world/tracks/SkidpadTrackStrategy.cpp
+++ b/sim/src/world/tracks/SkidpadTrackStrategy.cpp
@@ -1,0 +1,61 @@
+#include "sim/src/world/tracks/SkidpadTrackStrategy.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace fsai::world::tracks {
+
+fsai::sim::TrackData SkidpadTrackStrategy::Apply(const fsai::sim::TrackData& track) const {
+    fsai::sim::TrackData adjusted = track;
+
+    const double leftCircleCenterX = -9.25;
+    const double rightCircleCenterX = 9.25;
+    const double circleCenterZ = 0.0;
+    const double circleRadius = 9.0;
+    const double corridorMargin = 2.5;
+
+    auto moveCorridorConesToStart = [&](std::vector<Transform>& cones) {
+        std::vector<Transform> kept;
+        kept.reserve(cones.size());
+        for (const auto& cone : cones) {
+            const double distLeft = std::hypot(cone.position.x - leftCircleCenterX,
+                                               cone.position.z - circleCenterZ);
+            const double distRight = std::hypot(cone.position.x - rightCircleCenterX,
+                                                cone.position.z - circleCenterZ);
+            const bool isCorridorCone = (distLeft > circleRadius + corridorMargin) &&
+                                        (distRight > circleRadius + corridorMargin);
+            if (isCorridorCone) {
+                adjusted.startCones.push_back(cone);
+            } else {
+                kept.push_back(cone);
+            }
+        }
+        cones.swap(kept);
+    };
+
+    moveCorridorConesToStart(adjusted.leftCones);
+    moveCorridorConesToStart(adjusted.rightCones);
+
+    std::sort(adjusted.startCones.begin(), adjusted.startCones.end(),
+              [](const Transform& a, const Transform& b) {
+                  return a.position.z < b.position.z;
+              });
+
+    auto flipZ = [](std::vector<Transform>& transforms) {
+        for (auto& transform : transforms) {
+            transform.position.z = -transform.position.z;
+        }
+    };
+
+    flipZ(adjusted.startCones);
+    flipZ(adjusted.leftCones);
+    flipZ(adjusted.rightCones);
+    flipZ(adjusted.checkpoints);
+
+    std::swap(adjusted.leftCones, adjusted.rightCones);
+
+    return adjusted;
+}
+
+}  // namespace fsai::world::tracks
+

--- a/sim/src/world/tracks/SkidpadTrackStrategy.hpp
+++ b/sim/src/world/tracks/SkidpadTrackStrategy.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "sim/mission/MissionDefinition.hpp"
+#include "MissionDefinition.hpp"
 
 namespace fsai::world::tracks {
 

--- a/sim/src/world/tracks/SkidpadTrackStrategy.hpp
+++ b/sim/src/world/tracks/SkidpadTrackStrategy.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "sim/mission/MissionDefinition.hpp"
+
+namespace fsai::world::tracks {
+
+class SkidpadTrackStrategy {
+public:
+    fsai::sim::TrackData Apply(const fsai::sim::TrackData& track) const;
+};
+
+}  // namespace fsai::world::tracks
+

--- a/sim/tests/WorldTestHelper.hpp
+++ b/sim/tests/WorldTestHelper.hpp
@@ -4,6 +4,7 @@
 
 #include "World.hpp"
 #include "sim/mission/MissionDefinition.hpp"
+#include "sim/src/world/TrackBuilder.hpp"
 
 class WorldTestHelper {
 public:
@@ -58,7 +59,15 @@ public:
     }
 
     static void ConfigureTrack(World& world, const fsai::sim::TrackData& track) {
-        world.configureTrackState(track);
+        TrackBuilder builder;
+        fsai::sim::MissionDefinition mission = world.mission_;
+        mission.track = track;
+        mission.trackSource = fsai::sim::TrackSource::kCsv;
+        const TrackBuildResult trackState =
+            builder.Build(mission, world.pathConfig_, world.config.vehicleCollisionRadius);
+        world.trackState_ = trackState;
+        world.mission_ = mission;
+        world.configureTrackState(trackState);
     }
 
     static void SetCollisionRadius(World& world, float radius) {

--- a/sim/tests/WorldTestHelper.hpp
+++ b/sim/tests/WorldTestHelper.hpp
@@ -3,8 +3,8 @@
 #include <Eigen/Dense>
 
 #include "World.hpp"
-#include "sim/mission/MissionDefinition.hpp"
-#include "sim/src/world/TrackBuilder.hpp"
+#include "MissionDefinition.hpp"
+#include "TrackBuilder.hpp"
 
 class WorldTestHelper {
 public:


### PR DESCRIPTION
## Summary
- add TrackBuilder to build mission track data, cone positions, and collision geometry from path/track configs
- move skidpad cone mirroring and corridor handling into a dedicated strategy
- update World initialization and tests to consume immutable built track state

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692440b5049883248edbd0d55ca8e525)