### PR TITLE
Refine World vehicle context and command ingress

### DIFF
--- a/docs/architecture/simulation-data.md
+++ b/docs/architecture/simulation-data.md
@@ -9,13 +9,13 @@
 | Vehicle dynamics | `DynamicBicycle::updateState`, wheel-speed helpers | Vehicle dynamics model | `World` for inputs, mission state for timing | GUI/logging | `World::update` pushes sanitized inputs into the bicycle model, captures wheel speeds, and accumulates distance/time.【F:sim/src/World.cpp†L217-L283】
 | Collision detection | `detectCollisions`, gate/boundary segment builders | `World` | Track config | GUI/control | Detects gate crossings, lap completions, cone/boundary hits; may trigger resets or lap increments.【F:sim/src/World.cpp†L285-L386】
 | Control decisions | `computeRacingControl` (path search + controller) | Control module | `World` geometry and state | GUI/logging | Generates throttle/steer based on visible cones and checkpoints; feeds lookahead indices and best-path edges for visualization.【F:sim/src/World.cpp†L138-L164】
-| External control ingress | `setSvcuCommand`, public control fields | `World` | S-VCU UDP/CAN shim | Control/GUI | Stores latest S-VCU command so `World::update` can apply it when missions are running.【F:sim/src/World.cpp†L166-L215】
+| External control ingress | Per-frame `World::update` command input, public control fields | `World` | S-VCU UDP/CAN shim | Control/GUI | IO/control surfaces sanitize S-VCU inputs before invoking `World::update` with the neutral command for the current frame.【F:sim/src/World.cpp†L192-L274】
 | Telemetry emission | `telemetry` (to `Telemetry_Update`) | Telemetry layer | `World` state | GUI/logging | Pushes authoritative physics/mission state each frame.【F:sim/src/World.cpp†L383-L386】
 
 ## Public getters consumed by GUI/control (`sim/app/fsai_run.cpp`)
 
 * Rendering pulls cones, checkpoints, lookahead indices, vehicle pose, and detection overlays directly from the `World` getters for draw calls.【F:sim/app/fsai_run.cpp†L1322-L1465】
-* Control loop reads and optionally overrides `World` control fields (`throttleInput`, `brakeInput`, `steeringAngle`), invokes `computeRacingControl`, and applies `setSvcuCommand` for S-VCU handoff.【F:sim/app/fsai_run.cpp†L2057-L2187】
+* Control loop reads and optionally overrides `World` control fields (`throttleInput`, `brakeInput`, `steeringAngle`), invokes `computeRacingControl`, and forwards sanitized inputs through `World::update` for runtime state progression.【F:sim/app/fsai_run.cpp†L2138-L2340】
 * Runtime telemetry populates GUI/control panels using `World` getters for lap timing, distance, mission progress, and mission descriptors.【F:sim/app/fsai_run.cpp†L2247-L2291】
 
 ## S-VCU telemetry paths (ground truth vs. noisy sensors)

--- a/sim/tests/WorldBoundaryCollisionTest.cpp
+++ b/sim/tests/WorldBoundaryCollisionTest.cpp
@@ -17,7 +17,7 @@ Transform MakeTransform(float x, float z) {
 TEST(WorldBoundaryCollisionTest, LeftBoundaryTriggersReset) {
     World world;
     VehicleDynamics dynamics;
-    world.setVehicleDynamics(dynamics);
+    world.setVehicleContext(WorldTestHelper::MakeContext(dynamics));
 
     fsai::sim::TrackData track;
     track.leftCones.push_back(MakeTransform(-1.0f, 0.0f));

--- a/sim/tests/WorldGateTest.cpp
+++ b/sim/tests/WorldGateTest.cpp
@@ -5,7 +5,7 @@
 TEST(WorldGateTest, AdvancesCheckpointOnCrossing) {
     World world;
     VehicleDynamics dynamics;
-    world.setVehicleDynamics(dynamics);
+    world.setVehicleContext(WorldTestHelper::MakeContext(dynamics));
     WorldTestHelper::ConfigureSimpleGate(world);
     const auto initial = WorldTestHelper::Checkpoints(world);
 
@@ -26,7 +26,7 @@ TEST(WorldGateTest, AdvancesCheckpointOnCrossing) {
 TEST(WorldGateTest, GateIgnoresNonCrossingMotion) {
     World world;
     VehicleDynamics dynamics;
-    world.setVehicleDynamics(dynamics);
+    world.setVehicleContext(WorldTestHelper::MakeContext(dynamics));
     WorldTestHelper::ConfigureSimpleGate(world);
     const auto initial = WorldTestHelper::Checkpoints(world);
 

--- a/sim/tests/WorldTestHelper.hpp
+++ b/sim/tests/WorldTestHelper.hpp
@@ -36,6 +36,16 @@ public:
         world.insideLastCheckpoint_ = false;
     }
 
+    static WorldVehicleContext MakeContext(VehicleDynamics& dynamics) {
+        WorldVehicleContext context{};
+        context.dynamics = &dynamics;
+        context.dynamics_model = &dynamics.model();
+        context.reset_vehicle = [&dynamics](const VehicleSpawnState& spawn) {
+            dynamics.setState(spawn.state, spawn.transform);
+        };
+        return context;
+    }
+
     static std::vector<Vector3> Checkpoints(const World& world) {
         return world.checkpointPositions;
     }
@@ -45,11 +55,11 @@ public:
     }
 
     static void SetCarPosition(World& world, VehicleDynamics& dynamics, float x, float z) {
-        SetVehiclePose(world, dynamics, x, world.vehicleTransform().position.y, z);
+        SetVehiclePose(world, dynamics, x, world.vehicle_transform().position.y, z);
     }
 
     static void SetCarHeight(World& world, VehicleDynamics& dynamics, float y) {
-        const Transform& carTransform = world.vehicleTransform();
+        const Transform& carTransform = world.vehicle_transform();
         SetVehiclePose(world, dynamics, carTransform.position.x, y, carTransform.position.z);
     }
 
@@ -74,7 +84,7 @@ private:
         VehicleState state = dynamics.state();
         state.position = Eigen::Vector3d(static_cast<double>(x), static_cast<double>(z), state.position.z());
 
-        Transform transform = world.vehicleTransform();
+        Transform transform = world.vehicle_transform();
         transform.position.x = x;
         transform.position.y = y;
         transform.position.z = z;


### PR DESCRIPTION
## Summary
- add a WorldVehicleContext to supply vehicle dynamics access, reset callbacks, and spawn handling during world initialization
- drive World updates with per-frame control commands instead of stored SVCU packets and expose ground-truth only through IWorldView getters
- update control loop, tests, and docs to use the new context-driven interfaces

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692440b8a12c83249a5da0ef7741a457)