### PR TITLE
Refactor world runtime orchestration

### DIFF
--- a/sim/include/sim/WorldRuntime.hpp
+++ b/sim/include/sim/WorldRuntime.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <utility>
+
+#include <Eigen/Dense>
+
+#include "Transform.h"
+#include "sim/MissionRuntimeState.hpp"
+#include "sim/mission/MissionDefinition.hpp"
+#include "Vector.h"
+
+namespace fsai::sim {
+
+struct WorldRuntimeConfig {
+  float collision_threshold{2.5f};
+  float vehicle_collision_radius{0.386f};
+  float lap_completion_threshold{0.1f};
+};
+
+struct LapRecord {
+  double time_seconds{0.0};
+  double distance_meters{0.0};
+};
+
+class WorldRuntime {
+ public:
+  struct Events {
+    std::function<void()> on_reset_requested{};
+    std::function<void()> on_mission_complete{};
+  };
+
+  explicit WorldRuntime(MissionRuntimeState& mission_state);
+
+  void Configure(const MissionDefinition& mission,
+                 const std::vector<Vector3>& checkpoints,
+                 const WorldRuntimeConfig& config);
+
+  void InitializeLapTracking(const Transform& spawn_transform,
+                             const Vector3& last_checkpoint);
+
+  void AdvanceMission(double dt_seconds, const Eigen::Vector2d& velocity_2d);
+
+  std::optional<LapRecord> EvaluateLapCrossing(const Transform& car_transform,
+                                               const Vector3& last_checkpoint);
+
+  void UpdateStraightLineProgress(const Transform& car_transform);
+
+  void CheckMissionComplete();
+
+  void RequestReset();
+
+  void set_events(const Events& events) { events_ = events; }
+
+  double lap_time_seconds() const { return lap_time_seconds_; }
+  double lap_distance_meters() const { return lap_distance_meters_; }
+  const WorldRuntimeConfig& config() const { return config_; }
+
+ private:
+  struct StraightLineTracker {
+    bool valid{false};
+    Eigen::Vector2d origin{Eigen::Vector2d::Zero()};
+    Eigen::Vector2d direction{Eigen::Vector2d::UnitX()};
+    double length{0.0};
+  };
+
+  void configureStraightLineTracker(const MissionDefinition& mission,
+                                    const std::vector<Vector3>& checkpoints);
+  void resetLapMetrics();
+
+  MissionRuntimeState& mission_state_;
+  WorldRuntimeConfig config_{};
+  Events events_{};
+  bool inside_last_checkpoint_{false};
+  StraightLineTracker straight_tracker_{};
+  double lap_time_seconds_{0.0};
+  double lap_distance_meters_{0.0};
+};
+
+}  // namespace fsai::sim
+

--- a/sim/src/WorldRuntime.cpp
+++ b/sim/src/WorldRuntime.cpp
@@ -1,0 +1,125 @@
+#include "sim/WorldRuntime.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace fsai::sim {
+
+namespace {
+
+Eigen::Vector2d toVector2d(const Vector3& v) {
+  return Eigen::Vector2d(static_cast<double>(v.x), static_cast<double>(v.z));
+}
+
+}  // namespace
+
+WorldRuntime::WorldRuntime(MissionRuntimeState& mission_state)
+    : mission_state_(mission_state) {}
+
+void WorldRuntime::Configure(const MissionDefinition& mission,
+                             const std::vector<Vector3>& checkpoints,
+                             const WorldRuntimeConfig& config) {
+  mission_state_.Reset(mission);
+  config_ = config;
+  straight_tracker_ = {};
+  configureStraightLineTracker(mission, checkpoints);
+  inside_last_checkpoint_ = false;
+  resetLapMetrics();
+}
+
+void WorldRuntime::InitializeLapTracking(const Transform& spawn_transform,
+                                         const Vector3& last_checkpoint) {
+  const float dx = spawn_transform.position.x - last_checkpoint.x;
+  const float dz = spawn_transform.position.z - last_checkpoint.z;
+  const float dist = std::sqrt(dx * dx + dz * dz);
+  inside_last_checkpoint_ = dist < config_.lap_completion_threshold;
+}
+
+void WorldRuntime::AdvanceMission(double dt_seconds,
+                                  const Eigen::Vector2d& velocity_2d) {
+  if (mission_state_.mission_complete()) {
+    return;
+  }
+
+  mission_state_.Update(dt_seconds);
+  lap_time_seconds_ += dt_seconds;
+  lap_distance_meters_ += velocity_2d.norm() * dt_seconds;
+}
+
+std::optional<LapRecord> WorldRuntime::EvaluateLapCrossing(
+    const Transform& car_transform, const Vector3& last_checkpoint) {
+  const float dx = car_transform.position.x - last_checkpoint.x;
+  const float dz = car_transform.position.z - last_checkpoint.z;
+  const float dist_to_last = std::sqrt(dx * dx + dz * dz);
+  const bool inside_now = dist_to_last < config_.lap_completion_threshold;
+
+  if (inside_now && !inside_last_checkpoint_ && !mission_state_.mission_complete()) {
+    const LapRecord record{lap_time_seconds_, lap_distance_meters_};
+    mission_state_.RegisterLap(lap_time_seconds_, lap_distance_meters_);
+    resetLapMetrics();
+    inside_last_checkpoint_ = true;
+    return record;
+  }
+
+  inside_last_checkpoint_ = inside_now;
+  return std::nullopt;
+}
+
+void WorldRuntime::UpdateStraightLineProgress(const Transform& car_transform) {
+  if (!straight_tracker_.valid) {
+    return;
+  }
+
+  const Eigen::Vector2d position(static_cast<double>(car_transform.position.x),
+                                 static_cast<double>(car_transform.position.z));
+  const Eigen::Vector2d offset = position - straight_tracker_.origin;
+  const double projection = offset.dot(straight_tracker_.direction);
+  const double clamped = std::clamp(projection, 0.0, straight_tracker_.length);
+  mission_state_.SetStraightLineProgress(clamped);
+}
+
+void WorldRuntime::CheckMissionComplete() {
+  if (!mission_state_.mission_complete() || mission_state_.stop_commanded()) {
+    return;
+  }
+
+  mission_state_.MarkStopCommanded();
+  if (events_.on_mission_complete) {
+    events_.on_mission_complete();
+  }
+}
+
+void WorldRuntime::RequestReset() {
+  if (events_.on_reset_requested) {
+    events_.on_reset_requested();
+  }
+}
+
+void WorldRuntime::configureStraightLineTracker(
+    const MissionDefinition& mission, const std::vector<Vector3>& checkpoints) {
+  if (mission.descriptor.type != MissionType::kAcceleration ||
+      checkpoints.size() < 2) {
+    return;
+  }
+
+  const Eigen::Vector2d start = toVector2d(checkpoints.front());
+  const Eigen::Vector2d finish = toVector2d(checkpoints.back());
+  const Eigen::Vector2d delta = finish - start;
+  const double length = delta.norm();
+  if (length <= 1e-3) {
+    return;
+  }
+
+  straight_tracker_.valid = true;
+  straight_tracker_.origin = start;
+  straight_tracker_.direction = delta / length;
+  straight_tracker_.length = length;
+}
+
+void WorldRuntime::resetLapMetrics() {
+  lap_time_seconds_ = 0.0;
+  lap_distance_meters_ = 0.0;
+}
+
+}  // namespace fsai::sim
+


### PR DESCRIPTION
## Summary
- add a dedicated WorldRuntime helper to manage mission timing, lap thresholds, and straight-line tracking while surfacing mission state
- refactor the world update loop to follow a structured command ingest -> timing -> distance -> collision -> telemetry sequence driven by runtime config
- expose reset and mission-complete callbacks so external IO/control layers can react without accessing internals

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692440b8ad848324b10e4d176474c22e)