### PR TITLE
Refactor collision handling and reset policy

### DIFF
--- a/sim/src/world/CollisionService.cpp
+++ b/sim/src/world/CollisionService.cpp
@@ -1,0 +1,131 @@
+#include "world/CollisionService.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "Transform.h"
+#include "Vector.h"
+#include "sim/World.hpp"
+
+namespace {
+
+float distanceSquaredToSegment(const Vector2& point, const CollisionSegment& segment) {
+    const float ax = segment.start.x;
+    const float ay = segment.start.y;
+    const float bx = segment.end.x;
+    const float by = segment.end.y;
+    const float abx = bx - ax;
+    const float aby = by - ay;
+    const float lengthSq = abx * abx + aby * aby;
+    if (lengthSq <= std::numeric_limits<float>::epsilon()) {
+        const float dx = point.x - ax;
+        const float dy = point.y - ay;
+        return dx * dx + dy * dy;
+    }
+
+    const float t = ((point.x - ax) * abx + (point.y - ay) * aby) / lengthSq;
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    const float closestX = ax + clamped * abx;
+    const float closestY = ay + clamped * aby;
+    const float dx = point.x - closestX;
+    const float dy = point.y - closestY;
+    return dx * dx + dy * dy;
+}
+
+bool pointWithinBounds(const Vector2& point, const CollisionSegment& segment) {
+    return point.x >= segment.boundsMin.x && point.x <= segment.boundsMax.x &&
+           point.y >= segment.boundsMin.y && point.y <= segment.boundsMax.y;
+}
+
+}  // namespace
+
+CollisionService::CollisionService(const Config& config,
+                                   const std::vector<Cone>& startCones,
+                                   const std::vector<Cone>& leftCones,
+                                   const std::vector<Cone>& rightCones,
+                                   const std::vector<CollisionSegment>& gateSegments,
+                                   const std::vector<CollisionSegment>& boundarySegments,
+                                   float vehicleCollisionRadius)
+    : config_(config),
+      startCones_(startCones),
+      leftCones_(leftCones),
+      rightCones_(rightCones),
+      gateSegments_(gateSegments),
+      boundarySegments_(boundarySegments),
+      vehicleCollisionRadius_(vehicleCollisionRadius) {}
+
+CollisionService::Result CollisionService::Evaluate(const Transform& carTransform,
+                                                    const Vector3& lastCheckpoint,
+                                                    bool wasInsideLapZone) const {
+    const Vector2 carCenter{carTransform.position.x, carTransform.position.z};
+
+    Result result{};
+    result.insideLapZone = insideLapCompletionZone(carCenter, lastCheckpoint);
+    result.lapCompleted = result.insideLapZone && !wasInsideLapZone;
+    result.coneCollision = collidesWithCones(carCenter);
+    result.boundaryCollision = collidesWithBoundaries(carCenter);
+
+    return result;
+}
+
+bool CollisionService::collidesWithCones(const Vector2& carCenter) const {
+    const auto coneHit = [&](const Cone& cone) {
+        const float dx = carCenter.x - cone.position.x;
+        const float dz = carCenter.y - cone.position.z;
+        const float distance = std::sqrt(dx * dx + dz * dz);
+        const float combinedRadius = cone.radius + vehicleCollisionRadius_;
+        return distance < combinedRadius;
+    };
+
+    for (const auto& cone : startCones_) {
+        if (coneHit(cone)) {
+            return true;
+        }
+    }
+    for (const auto& cone : leftCones_) {
+        if (coneHit(cone)) {
+            return true;
+        }
+    }
+    for (const auto& cone : rightCones_) {
+        if (coneHit(cone)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CollisionService::collidesWithBoundaries(const Vector2& carCenter) const {
+    const float collisionRadiusSq = vehicleCollisionRadius_ * vehicleCollisionRadius_;
+
+    auto segmentHit = [&](const CollisionSegment& segment) {
+        if (!pointWithinBounds(carCenter, segment)) {
+            return false;
+        }
+        return distanceSquaredToSegment(carCenter, segment) < collisionRadiusSq;
+    };
+
+    for (const auto& segment : gateSegments_) {
+        if (segmentHit(segment)) {
+            break;
+        }
+    }
+
+    for (const auto& segment : boundarySegments_) {
+        if (segmentHit(segment)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool CollisionService::insideLapCompletionZone(const Vector2& carCenter,
+                                               const Vector3& lastCheckpoint) const {
+    const float dx = carCenter.x - lastCheckpoint.x;
+    const float dz = carCenter.y - lastCheckpoint.z;
+    const float distToLast = std::sqrt(dx * dx + dz * dz);
+    return distToLast < config_.lapCompletionThreshold;
+}
+

--- a/sim/src/world/CollisionService.hpp
+++ b/sim/src/world/CollisionService.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <vector>
+
+struct Vector2;
+struct Vector3;
+struct Transform;
+struct Cone;
+struct CollisionSegment;
+
+class CollisionService {
+ public:
+  struct Config {
+    float lapCompletionThreshold{0.2f};
+  };
+
+  CollisionService(const Config& config,
+                   const std::vector<Cone>& startCones,
+                   const std::vector<Cone>& leftCones,
+                   const std::vector<Cone>& rightCones,
+                   const std::vector<CollisionSegment>& gateSegments,
+                   const std::vector<CollisionSegment>& boundarySegments,
+                   float vehicleCollisionRadius);
+
+  struct Result {
+    bool coneCollision{false};
+    bool boundaryCollision{false};
+    bool lapCompleted{false};
+    bool insideLapZone{false};
+  };
+
+  Result Evaluate(const Transform& carTransform,
+                  const Vector3& lastCheckpoint,
+                  bool wasInsideLapZone) const;
+
+ private:
+  bool collidesWithCones(const Vector2& carCenter) const;
+  bool collidesWithBoundaries(const Vector2& carCenter) const;
+  bool insideLapCompletionZone(const Vector2& carCenter,
+                               const Vector3& lastCheckpoint) const;
+
+  const Config config_;
+  const std::vector<Cone>& startCones_;
+  const std::vector<Cone>& leftCones_;
+  const std::vector<Cone>& rightCones_;
+  const std::vector<CollisionSegment>& gateSegments_;
+  const std::vector<CollisionSegment>& boundarySegments_;
+  float vehicleCollisionRadius_{0.0f};
+};
+

--- a/sim/src/world/ResetPolicy.cpp
+++ b/sim/src/world/ResetPolicy.cpp
@@ -1,0 +1,17 @@
+#include "world/ResetPolicy.hpp"
+
+ResetPolicy::ResetPolicy(const Config& config) : config_(config) {}
+
+bool ResetPolicy::ShouldRegenerate(const fsai::sim::MissionDefinition& mission) const {
+    if (!config_.regenerateOnCollision) {
+        return false;
+    }
+    if (!mission.allowRegeneration) {
+        return false;
+    }
+    if (config_.regenerateRandomTracksOnly && mission.trackSource != fsai::sim::TrackSource::kRandom) {
+        return false;
+    }
+    return true;
+}
+

--- a/sim/src/world/ResetPolicy.hpp
+++ b/sim/src/world/ResetPolicy.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "sim/mission/MissionDefinition.hpp"
+
+class ResetPolicy {
+ public:
+  struct Config {
+    bool regenerateOnCollision{true};
+    bool regenerateRandomTracksOnly{false};
+  };
+
+  ResetPolicy() = default;
+  explicit ResetPolicy(const Config& config);
+
+  bool ShouldRegenerate(const fsai::sim::MissionDefinition& mission) const;
+
+ private:
+  Config config_{};
+};
+


### PR DESCRIPTION
## Summary
- add a dedicated collision service that uses immutable cone geometry and configurable thresholds
- introduce a reset policy and reset event emission to control when tracks regenerate
- update world flow to route collision decisions through the new services

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692440b9df3c8324b08ec106fa77731c)