### PR TITLE
Add debug packet publisher and route debug data through adapters

### DIFF
--- a/docs/architecture/boundary-sequence.md
+++ b/docs/architecture/boundary-sequence.md
@@ -15,7 +15,7 @@ sequenceDiagram
     IO->>World: publish_ground_truth(world)
     World->>Dyn: set_command(throttle, brake, steer)
     Dyn-->>World: state(), transform(), wheels_info()
-    World-->>IO: ground_truth_detections(), vehicle_state()
+    World-->>IO: vehicle_state()
     IO-->>Control: latest_raw_telemetry()
 ```
 
@@ -32,7 +32,7 @@ sequenceDiagram
     IO->>World: publish_ground_truth(world)
     World->>Dyn: set_command(throttle, brake, steer)
     Dyn-->>World: state(), transform(), wheels_info()
-    World-->>IO: ground_truth_detections(), vehicle_state()
+    World-->>IO: vehicle_state()
     IO->>IO: set_noise_config(TelemetryNoiseConfig)
     IO-->>Control: latest_noisy_telemetry(), latest_stereo_frame()
 ```

--- a/docs/architecture/simulation-data.md
+++ b/docs/architecture/simulation-data.md
@@ -8,13 +8,13 @@
 | Mission runtime bookkeeping | `configureMissionRuntime`, `handleMissionCompletion` | `World` | Mission runtime state | Control loop | Updates mission timers/segments and enforces stop on completion.【F:sim/src/World.cpp†L434-L490】
 | Vehicle dynamics | `DynamicBicycle::updateState`, wheel-speed helpers | Vehicle dynamics model | `World` for inputs, mission state for timing | GUI/logging | `World::update` pushes sanitized inputs into the bicycle model, captures wheel speeds, and accumulates distance/time.【F:sim/src/World.cpp†L217-L283】
 | Collision detection | `detectCollisions`, gate/boundary segment builders | `World` | Track config | GUI/control | Detects gate crossings, lap completions, cone/boundary hits; may trigger resets or lap increments.【F:sim/src/World.cpp†L285-L386】
-| Control decisions | `computeRacingControl` (path search + controller) | Control module | `World` geometry and state | GUI/logging | Generates throttle/steer based on visible cones and checkpoints; feeds lookahead indices and best-path edges for visualization.【F:sim/src/World.cpp†L138-L164】
+| Control decisions | `computeRacingControl` (path search + controller) | Control module | `World` geometry and state | GUI/logging | Generates throttle/steer based on visible cones and checkpoints; feeds lookahead indices and streams controller paths through the debug publisher.【F:sim/src/World.cpp†L138-L164】
 | External control ingress | `setSvcuCommand`, public control fields | `World` | S-VCU UDP/CAN shim | Control/GUI | Stores latest S-VCU command so `World::update` can apply it when missions are running.【F:sim/src/World.cpp†L166-L215】
 | Telemetry emission | `telemetry` (to `Telemetry_Update`) | Telemetry layer | `World` state | GUI/logging | Pushes authoritative physics/mission state each frame.【F:sim/src/World.cpp†L383-L386】
 
 ## Public getters consumed by GUI/control (`sim/app/fsai_run.cpp`)
 
-* Rendering pulls cones, checkpoints, lookahead indices, vehicle pose, and detection overlays directly from the `World` getters for draw calls.【F:sim/app/fsai_run.cpp†L1322-L1465】
+* Rendering pulls cones, checkpoints, lookahead indices, and vehicle pose from the `World` getters while overlaying debug visualizations from the latest debug packet.【F:sim/app/fsai_run.cpp†L1322-L1465】
 * Control loop reads and optionally overrides `World` control fields (`throttleInput`, `brakeInput`, `steeringAngle`), invokes `computeRacingControl`, and applies `setSvcuCommand` for S-VCU handoff.【F:sim/app/fsai_run.cpp†L2057-L2187】
 * Runtime telemetry populates GUI/control panels using `World` getters for lap timing, distance, mission progress, and mission descriptors.【F:sim/app/fsai_run.cpp†L2247-L2291】
 
@@ -26,6 +26,6 @@
 
 ## Surfaces that should be private/mediated
 
-* Mutable `World` fields (`throttleInput`, `brakeInput`, `steeringAngle`, `coneDetections`, `bestPathEdges`, `useController`, `regenTrack`) are public and written by UI/control code, bypassing validation or mission state checks.【F:sim/include/sim/World.hpp†L56-L64】【F:sim/app/fsai_run.cpp†L2057-L2187】
+* Mutable `World` fields (`throttleInput`, `brakeInput`, `steeringAngle`, `useController`, `regenTrack`) are public and written by UI/control code, bypassing validation or mission state checks; debug-only data is mediated through a publisher instead of writable members.【F:sim/include/sim/World.hpp†L56-L64】【F:sim/app/fsai_run.cpp†L2057-L2187】
 * Geometry accessors expose mutable vectors (cones, checkpoints) used for rendering and path planning; callers could hold stale references across resets/regenerations.【F:sim/include/sim/World.hpp†L66-L115】【F:sim/app/fsai_run.cpp†L1322-L1465】
 * Telemetry uses authoritative `World` state, but S-VCU transmissions build on noisy sensor facades; separating “truth” from “telemetry” producers would clarify which consumers should see which feed.【F:sim/app/fsai_run.cpp†L2230-L2291】【F:sim/app/fsai_run.cpp†L2391-L2479】

--- a/sim/app/gui_world_adapter.cpp
+++ b/sim/app/gui_world_adapter.cpp
@@ -8,7 +8,6 @@ GuiWorldSnapshot GuiWorldAdapter::snapshot() const {
   snap.left_cones = world_.left_cones();
   snap.right_cones = world_.right_cones();
   snap.checkpoints = world_.checkpoint_positions();
-  snap.best_path_edges = world_.best_path_edges();
   snap.lookahead = world_.lookahead_indices();
   snap.vehicle_transform = world_.vehicle_transform();
   snap.vehicle_state = world_.vehicle_state();
@@ -17,7 +16,7 @@ GuiWorldSnapshot GuiWorldAdapter::snapshot() const {
   snap.total_distance_meters = world_.total_distance_meters();
   snap.time_step_seconds = world_.time_step_seconds();
   snap.lap_count = world_.lap_count();
-  snap.detections = &world_.ground_truth_detections();
+  snap.debug = debug_;
   return snap;
 }
 

--- a/sim/app/gui_world_adapter.hpp
+++ b/sim/app/gui_world_adapter.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -8,6 +9,7 @@
 #include "VehicleState.hpp"
 #include "sim/MissionRuntimeState.hpp"
 #include "sim/architecture/IWorldView.hpp"
+#include "sim/architecture/WorldDebugPacket.hpp"
 
 namespace fsai::sim::app {
 
@@ -16,7 +18,6 @@ struct GuiWorldSnapshot {
   std::vector<Vector3> left_cones;
   std::vector<Vector3> right_cones;
   std::vector<Vector3> checkpoints;
-  std::vector<std::pair<Vector2, Vector2>> best_path_edges;
   LookaheadIndices lookahead{};
   Transform vehicle_transform{};
   VehicleState vehicle_state{};
@@ -25,17 +26,20 @@ struct GuiWorldSnapshot {
   double total_distance_meters{0.0};
   double time_step_seconds{0.0};
   int lap_count{0};
-  const std::vector<FsaiConeDet>* detections{nullptr};
+  std::optional<fsai::world::WorldDebugPacket> debug;
 };
 
 class GuiWorldAdapter {
  public:
-  explicit GuiWorldAdapter(const fsai::world::IWorldView& world) : world_(world) {}
+  GuiWorldAdapter(const fsai::world::IWorldView& world,
+                  std::optional<fsai::world::WorldDebugPacket> debug)
+      : world_(world), debug_(std::move(debug)) {}
 
   GuiWorldSnapshot snapshot() const;
 
  private:
   const fsai::world::IWorldView& world_;
+  std::optional<fsai::world::WorldDebugPacket> debug_{};
 };
 
 }  // namespace fsai::sim::app

--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -14,6 +14,7 @@
 #include "PathGenerator.hpp"
 #include "TrackGenerator.hpp"
 #include "sim/architecture/IWorldView.hpp"
+#include "sim/architecture/WorldDebugPacket.hpp"
 #include "sim/mission/MissionDefinition.hpp"
 #include "sim/MissionRuntimeState.hpp"
 
@@ -64,8 +65,6 @@ public:
     float brakeInput{0.0f};
     int useController{1};
     int regenTrack{1};
-    std::vector<std::pair<Vector2, Vector2>> bestPathEdges {};
-    std::vector<FsaiConeDet> coneDetections {};
 
 
     const VehicleState& vehicleState() const { return vehicleDynamics().state(); }
@@ -112,12 +111,13 @@ public:
     double total_distance_meters() const override { return totalDistance; }
     double time_step_seconds() const override { return deltaTime; }
     int lap_count() const override { return lapCount; }
-    const std::vector<std::pair<Vector2, Vector2>>& best_path_edges() const override { return bestPathEdges; }
-    const std::vector<FsaiConeDet>& ground_truth_detections() const override { return coneDetections; }
     bool vehicle_reset_pending() const override { return vehicleResetPending_; }
     void acknowledge_vehicle_reset(const Transform& appliedTransform) override {
         acknowledgeVehicleReset(appliedTransform);
     }
+
+    void set_debug_publisher(fsai::world::IWorldDebugPublisher* publisher) { debugPublisher_ = publisher; }
+    void update_debug_detections(const std::vector<FsaiConeDet>& detections);
 
     void setVehicleDynamics(const VehicleDynamics& vehicleDynamics);
 
@@ -169,6 +169,9 @@ private:
 
     ControllerConfig racingConfig{};
     LookaheadIndices lookaheadIndices{};
+
+    fsai::world::IWorldDebugPublisher* debugPublisher_{nullptr};
+    fsai::world::WorldDebugPacket debugPacket_{};
 
     double totalTime{0.0};
     double deltaTime{0.0};

--- a/sim/include/sim/architecture/IWorldView.hpp
+++ b/sim/include/sim/architecture/IWorldView.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 #include "MissionRuntimeState.hpp"
@@ -33,7 +32,6 @@ class IWorldView {
   virtual const std::vector<Vector3>& left_cones() const = 0;
   virtual const std::vector<Vector3>& right_cones() const = 0;
   virtual const LookaheadIndices& lookahead_indices() const = 0;
-  virtual const std::vector<std::pair<Vector2, Vector2>>& best_path_edges() const = 0;
 
   // --- Mission/runtime bookkeeping ---
   virtual const fsai::sim::MissionRuntimeState& mission_runtime() const = 0;
@@ -41,9 +39,6 @@ class IWorldView {
   virtual double total_distance_meters() const = 0;
   virtual double time_step_seconds() const = 0;
   virtual int lap_count() const = 0;
-
-  // --- Sensor/vision ground truth ---
-  virtual const std::vector<FsaiConeDet>& ground_truth_detections() const = 0;
 
   // --- Lifecycle helpers for consumers holding stale state ---
   virtual bool vehicle_reset_pending() const = 0;

--- a/sim/include/sim/architecture/WorldDebugPacket.hpp
+++ b/sim/include/sim/architecture/WorldDebugPacket.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "Vector.h"
+#include "common/types.h"
+
+namespace fsai::world {
+
+struct WorldDebugPacket {
+  std::vector<Vector3> start_cones;
+  std::vector<Vector3> left_cones;
+  std::vector<Vector3> right_cones;
+  std::vector<Vector3> checkpoints;
+  std::vector<std::pair<Vector2, Vector2>> controller_path;
+  std::vector<FsaiConeDet> detections;
+};
+
+class IWorldDebugPublisher {
+ public:
+  virtual ~IWorldDebugPublisher() = default;
+
+  virtual void set_debug_mode(bool enabled) = 0;
+  virtual void publish(const WorldDebugPacket& packet) = 0;
+  virtual std::optional<WorldDebugPacket> latest_packet() const = 0;
+};
+
+class InProcessWorldDebugPublisher final : public IWorldDebugPublisher {
+ public:
+  using Subscriber = std::function<void(const WorldDebugPacket&)>;
+
+  void set_debug_mode(bool enabled) override { debug_mode_ = enabled; }
+
+  void set_subscriber(Subscriber subscriber) { subscriber_ = std::move(subscriber); }
+
+  void publish(const WorldDebugPacket& packet) override {
+    if (!debug_mode_) {
+      return;
+    }
+
+    latest_ = packet;
+    if (subscriber_) {
+      subscriber_.value()(packet);
+    }
+  }
+
+  std::optional<WorldDebugPacket> latest_packet() const override { return latest_; }
+
+ private:
+  bool debug_mode_{false};
+  std::optional<WorldDebugPacket> latest_{};
+  std::optional<Subscriber> subscriber_{};
+};
+
+}  // namespace fsai::world
+

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -152,7 +152,7 @@ bool World::computeRacingControl(double dt, float& throttle_out, float& steering
     auto [nodes, adj] = generateGraph(triangulation, getCarFront(vehicleState()), coneToSide);
     auto searchResult = beamSearch(adj, nodes, getCarFront(vehicleState()), 30, 2, 20);
     auto pathNodes = searchResult.first;
-    bestPathEdges = searchResult.second;
+    debugPacket_.controller_path = searchResult.second;
     auto checkpoints = pathNodesToCheckpoints(pathNodes);
     lookaheadIndices = Controller_GetLookaheadIndices(
         static_cast<int>(checkpointPositions.size()), carSpeed, &racingConfig);
@@ -162,6 +162,10 @@ bool World::computeRacingControl(double dt, float& throttle_out, float& steering
     steering_out = Controller_GetSteeringInput(
         checkpointPositions.data(), static_cast<int>(checkpointPositions.size()),
         carSpeed, &carTransform, &racingConfig, dt);
+    if (debugPublisher_) {
+        debugPublisher_->publish(debugPacket_);
+    }
+
     return true;
 }
 
@@ -170,6 +174,13 @@ void World::setSvcuCommand(float throttle, float brake, float steer) {
     lastSvcuBrake_ = brake;
     lastSvcuSteer_ = steer;
     hasSvcuCommand_ = true;
+}
+
+void World::update_debug_detections(const std::vector<FsaiConeDet>& detections) {
+    debugPacket_.detections = detections;
+    if (debugPublisher_) {
+        debugPublisher_->publish(debugPacket_);
+    }
 }
 
 void World::setVehicleDynamics(const VehicleDynamics& vehicleDynamics) {
@@ -395,6 +406,12 @@ void World::configureTrackState(const fsai::sim::TrackData& track) {
     for (const auto& rc : track.rightCones)
         rightCones.push_back(makeCone(rc, ConeType::Right));
 
+    debugPacket_.checkpoints = checkpointPositions;
+    debugPacket_.start_cones.clear();
+    debugPacket_.left_cones.clear();
+    debugPacket_.right_cones.clear();
+    debugPacket_.detections.clear();
+
     bool isSkidpad = (mission_.descriptor.type == fsai::sim::MissionType::kSkidpad);
 
     // =========================================================================
@@ -495,6 +512,13 @@ void World::configureTrackState(const fsai::sim::TrackData& track) {
     };
 
     rebuildConePositions();
+
+    debugPacket_.start_cones = startConePositions_;
+    debugPacket_.left_cones = leftConePositions_;
+    debugPacket_.right_cones = rightConePositions_;
+    if (debugPublisher_) {
+        debugPublisher_->publish(debugPacket_);
+    }
 
     // Rest of your original code continues here...
     if (!leftCones.empty() && !rightCones.empty()) {
@@ -717,6 +741,25 @@ void World::moveNextCheckpointToLast() {
     if (!gateSegments_.empty()) {
         std::rotate(gateSegments_.begin(), gateSegments_.begin() + 1, gateSegments_.end());
     }
+    startConePositions_.clear();
+    leftConePositions_.clear();
+    rightConePositions_.clear();
+    for (const auto& cone : startCones) {
+        startConePositions_.push_back(cone.position);
+    }
+    for (const auto& cone : leftCones) {
+        leftConePositions_.push_back(cone.position);
+    }
+    for (const auto& cone : rightCones) {
+        rightConePositions_.push_back(cone.position);
+    }
+    debugPacket_.checkpoints = checkpointPositions;
+    debugPacket_.start_cones = startConePositions_;
+    debugPacket_.left_cones = leftConePositions_;
+    debugPacket_.right_cones = rightConePositions_;
+    if (debugPublisher_) {
+        debugPublisher_->publish(debugPacket_);
+    }
 }
 
 void World::reset() {
@@ -743,6 +786,10 @@ void World::reset() {
     const float initDz = spawnState_.transform.position.z - lastCheckpoint.z;
     const float initDist = std::sqrt(initDx * initDx + initDz * initDz);
     insideLastCheckpoint_ = initDist < config.lapCompletionThreshold;
-    coneDetections.clear();
+    debugPacket_.controller_path.clear();
+    debugPacket_.detections.clear();
+    if (debugPublisher_) {
+        debugPublisher_->publish(debugPacket_);
+    }
     vehicleResetPending_ = true;
 }


### PR DESCRIPTION
## Summary
- add a world debug packet publisher that gates emissions behind debug mode
- publish controller path, cones, checkpoints, and detections through debug packets instead of mutable world fields
- update GUI adapters and documentation to reflect the new debug data flow and keep ground-truth telemetry within IWorldView

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692440ba74348324accea631fc0fd152)