### PR TITLE
Add YAML world configuration loader

### DIFF
--- a/configs/sim/world.yaml
+++ b/configs/sim/world.yaml
@@ -1,0 +1,7 @@
+collision_threshold: 1.75
+vehicle_collision_radius: 0.386
+lap_completion_threshold: 0.2
+controller:
+  speed_lookahead_sensitivity: 0.5
+  steering_lookahead_sensitivity: 0.0
+  acceleration_factor: 0.0019

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -50,6 +50,7 @@
 #include "vision/detection_buffer_registry.hpp"
 #include "types.h"
 #include "World.hpp"
+#include "sim/WorldConfigLoader.hpp"
 #include "sim/cone_constants.hpp"
 #include "sim/mission/MissionDefinition.hpp"
 #include "sim/mission/TrackCsvLoader.hpp"
@@ -265,6 +266,7 @@ constexpr double kBaseLatitudeDeg = 37.4275;
 constexpr double kBaseLongitudeDeg = -122.1697;
 constexpr double kMetersPerDegreeLat = 111111.0;
 constexpr const char* kDefaultSensorConfig = "configs/sim/sensors.yaml";
+constexpr const char* kDefaultWorldConfig = "configs/sim/world.yaml";
 
 
 template <size_t Capacity>
@@ -1897,7 +1899,9 @@ int main(int argc, char* argv[]) {
   const VehicleParam vehicle_param = VehicleParam::loadFromFile(vehicle_config_path.c_str());
   VehicleDynamics vehicle_dynamics(vehicle_param);
   World world;
-  WorldConfig world_config{mission_definition};
+  const auto world_config_path = MakeProjectRelativePath(std::filesystem::path(kDefaultWorldConfig));
+  const WorldConfig world_config =
+      fsai::sim::WorldConfigLoader::FromFile(world_config_path.string(), mission_definition);
   world.init(vehicle_dynamics, world_config);
   vehicle_dynamics.setState(world.vehicleSpawnState().state,
                             world.vehicleSpawnState().transform);

--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -38,8 +38,18 @@ struct CollisionSegment {
     Vector2 boundsMax{0.0f, 0.0f};
 };
 
+struct WorldRuntimeConfig {
+    float collisionThreshold{1.75f};
+    float vehicleCollisionRadius{0.386f};
+    float lapCompletionThreshold{0.2f};
+    float speedLookAheadSensitivity{0.5f};
+    float steeringLookAheadSensitivity{0.0f};
+    float accelerationFactor{0.0019f};
+};
+
 struct WorldConfig {
     fsai::sim::MissionDefinition mission;
+    WorldRuntimeConfig runtime{};
 };
 
 class World : public fsai::world::IWorldView {

--- a/sim/include/sim/WorldConfigLoader.hpp
+++ b/sim/include/sim/WorldConfigLoader.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+#include "World.hpp"
+
+namespace fsai::sim {
+
+class WorldConfigLoader {
+public:
+    static WorldConfig FromFile(const std::string& path, const MissionDefinition& mission);
+};
+
+}  // namespace fsai::sim
+

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -194,9 +194,9 @@ void World::init(const VehicleDynamics& vehicleDynamics, const WorldConfig& worl
         throw std::runtime_error("MissionDefinition did not provide any checkpoints");
     }
 
-    this->config.collisionThreshold = 1.75f;
-    this->config.vehicleCollisionRadius = 0.5f - kSmallConeRadiusMeters;
-    this->config.lapCompletionThreshold = 0.2f;
+    this->config.collisionThreshold = worldConfig.runtime.collisionThreshold;
+    this->config.vehicleCollisionRadius = worldConfig.runtime.vehicleCollisionRadius;
+    this->config.lapCompletionThreshold = worldConfig.runtime.lapCompletionThreshold;
 
     configureTrackState(mission_.track);
     configureMissionRuntime();
@@ -209,9 +209,9 @@ void World::init(const VehicleDynamics& vehicleDynamics, const WorldConfig& worl
     useController = 1;
     regenTrack = mission_.allowRegeneration ? 1 : 0;
 
-    racingConfig.speedLookAheadSensitivity = 0.5f;
-    racingConfig.steeringLookAheadSensitivity = 0;
-    racingConfig.accelerationFactor = 0.0019f;
+    racingConfig.speedLookAheadSensitivity = worldConfig.runtime.speedLookAheadSensitivity;
+    racingConfig.steeringLookAheadSensitivity = worldConfig.runtime.steeringLookAheadSensitivity;
+    racingConfig.accelerationFactor = worldConfig.runtime.accelerationFactor;
 
     initializeVehiclePose();
     vehicleResetPending_ = true;

--- a/sim/src/WorldConfigLoader.cpp
+++ b/sim/src/WorldConfigLoader.cpp
@@ -1,0 +1,91 @@
+#include "sim/WorldConfigLoader.hpp"
+
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+
+#include <yaml-cpp/yaml.h>
+
+namespace {
+
+using fsai::sim::MissionDefinition;
+using fsai::sim::WorldConfig;
+using fsai::sim::WorldRuntimeConfig;
+
+std::string BuildMissingFieldMessage(const std::string& path, const std::string& field) {
+    std::ostringstream oss;
+    oss << "Missing required field '" << field << "' in " << path;
+    return oss.str();
+}
+
+std::string BuildInvalidFieldMessage(const std::string& path, const std::string& field) {
+    std::ostringstream oss;
+    oss << "Invalid value for '" << field << "' in " << path;
+    return oss.str();
+}
+
+float RequireFloat(const YAML::Node& node, const std::string& key, const std::string& path) {
+    const auto value_node = node[key];
+    if (!value_node || !value_node.IsScalar()) {
+        throw std::runtime_error(BuildMissingFieldMessage(path, key));
+    }
+    try {
+        return value_node.as<float>();
+    } catch (const YAML::BadConversion&) {
+        throw std::runtime_error(BuildInvalidFieldMessage(path, key));
+    }
+}
+
+void ValidatePositive(const float value, const std::string& path, const std::string& field) {
+    if (!std::isfinite(value) || value <= 0.0f) {
+        throw std::runtime_error(BuildInvalidFieldMessage(path, field));
+    }
+}
+
+void ValidateNonNegative(const float value, const std::string& path, const std::string& field) {
+    if (!std::isfinite(value) || value < 0.0f) {
+        throw std::runtime_error(BuildInvalidFieldMessage(path, field));
+    }
+}
+
+}  // namespace
+
+namespace fsai::sim {
+
+WorldConfig WorldConfigLoader::FromFile(const std::string& path, const MissionDefinition& mission) {
+    YAML::Node root = YAML::LoadFile(path);
+    if (!root || !root.IsMap()) {
+        throw std::runtime_error("Invalid or missing YAML root: " + path);
+    }
+
+    WorldRuntimeConfig runtime{};
+    runtime.collisionThreshold = RequireFloat(root, "collision_threshold", path);
+    runtime.vehicleCollisionRadius = RequireFloat(root, "vehicle_collision_radius", path);
+    runtime.lapCompletionThreshold = RequireFloat(root, "lap_completion_threshold", path);
+
+    const auto controller_node = root["controller"];
+    if (!controller_node || !controller_node.IsMap()) {
+        throw std::runtime_error(BuildMissingFieldMessage(path, "controller"));
+    }
+
+    runtime.speedLookAheadSensitivity =
+        RequireFloat(controller_node, "speed_lookahead_sensitivity", path);
+    runtime.steeringLookAheadSensitivity =
+        RequireFloat(controller_node, "steering_lookahead_sensitivity", path);
+    runtime.accelerationFactor = RequireFloat(controller_node, "acceleration_factor", path);
+
+    ValidatePositive(runtime.collisionThreshold, path, "collision_threshold");
+    ValidatePositive(runtime.vehicleCollisionRadius, path, "vehicle_collision_radius");
+    ValidatePositive(runtime.lapCompletionThreshold, path, "lap_completion_threshold");
+    ValidateNonNegative(runtime.speedLookAheadSensitivity, path, "speed_lookahead_sensitivity");
+    ValidateNonNegative(runtime.steeringLookAheadSensitivity, path,
+                        "steering_lookahead_sensitivity");
+    ValidatePositive(runtime.accelerationFactor, path, "acceleration_factor");
+
+    WorldConfig config{mission};
+    config.runtime = runtime;
+    return config;
+}
+
+}  // namespace fsai::sim
+

--- a/sim/tests/WorldConfigLoaderTest.cpp
+++ b/sim/tests/WorldConfigLoaderTest.cpp
@@ -1,0 +1,79 @@
+#include "gtest/gtest.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include "World.hpp"
+#include "sim/WorldConfigLoader.hpp"
+#include "sim/mission/MissionDefinition.hpp"
+#include "VehicleState.hpp"
+#include "sim/tests/WorldTestHelper.hpp"
+
+namespace fs = std::filesystem;
+
+namespace {
+Transform MakeTransform(float x, float z) {
+    Transform t{};
+    t.position.x = x;
+    t.position.y = 0.0f;
+    t.position.z = z;
+    t.yaw = 0.0f;
+    return t;
+}
+}
+
+TEST(WorldConfigLoaderTest, LoadsDefaultConfigFile) {
+    fsai::sim::MissionDefinition mission{};
+    const auto root = fs::path(__FILE__).parent_path().parent_path();
+    const auto config_path = root / "configs/sim/world.yaml";
+    const auto config = fsai::sim::WorldConfigLoader::FromFile(config_path.string(), mission);
+
+    EXPECT_FLOAT_EQ(config.runtime.collisionThreshold, 1.75f);
+    EXPECT_FLOAT_EQ(config.runtime.vehicleCollisionRadius, 0.386f);
+    EXPECT_FLOAT_EQ(config.runtime.lapCompletionThreshold, 0.2f);
+    EXPECT_FLOAT_EQ(config.runtime.speedLookAheadSensitivity, 0.5f);
+    EXPECT_FLOAT_EQ(config.runtime.steeringLookAheadSensitivity, 0.0f);
+    EXPECT_FLOAT_EQ(config.runtime.accelerationFactor, 0.0019f);
+}
+
+TEST(WorldConfigLoaderTest, AppliesConfigToWorldRuntime) {
+    const fs::path temp_config = fs::temp_directory_path() / "world_config_test.yaml";
+    std::ofstream out(temp_config);
+    out << "collision_threshold: 3.25\n";
+    out << "vehicle_collision_radius: 0.42\n";
+    out << "lap_completion_threshold: 0.55\n";
+    out << "controller:\n";
+    out << "  speed_lookahead_sensitivity: 0.9\n";
+    out << "  steering_lookahead_sensitivity: 1.1\n";
+    out << "  acceleration_factor: 0.0033\n";
+    out.close();
+
+    fsai::sim::MissionDefinition mission{};
+    mission.trackSource = fsai::sim::TrackSource::kCsv;
+    mission.track.checkpoints = {MakeTransform(0.0f, 0.0f), MakeTransform(0.0f, 10.0f)};
+    mission.track.leftCones = {MakeTransform(-1.0f, 0.0f), MakeTransform(-1.0f, 10.0f)};
+    mission.track.rightCones = {MakeTransform(1.0f, 0.0f), MakeTransform(1.0f, 10.0f)};
+
+    auto world_config = fsai::sim::WorldConfigLoader::FromFile(temp_config.string(), mission);
+
+    VehicleDynamics dynamics;
+    World world;
+    world.init(dynamics, world_config);
+
+    EXPECT_FLOAT_EQ(WorldTestHelper::CollisionThreshold(world), 3.25f);
+    EXPECT_FLOAT_EQ(WorldTestHelper::VehicleCollisionRadius(world), 0.42f);
+    EXPECT_FLOAT_EQ(WorldTestHelper::LapCompletionThreshold(world), 0.55f);
+
+    const auto racing = WorldTestHelper::RacingControllerConfig(world);
+    EXPECT_FLOAT_EQ(racing.speedLookAheadSensitivity, 0.9f);
+    EXPECT_FLOAT_EQ(racing.steeringLookAheadSensitivity, 1.1f);
+    EXPECT_FLOAT_EQ(racing.accelerationFactor, 0.0033f);
+
+    fs::remove(temp_config);
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+

--- a/sim/tests/WorldTestHelper.hpp
+++ b/sim/tests/WorldTestHelper.hpp
@@ -69,6 +69,11 @@ public:
         world.insideLastCheckpoint_ = inside;
     }
 
+    static float CollisionThreshold(const World& world) { return world.config.collisionThreshold; }
+    static float VehicleCollisionRadius(const World& world) { return world.config.vehicleCollisionRadius; }
+    static float LapCompletionThreshold(const World& world) { return world.config.lapCompletionThreshold; }
+    static ControllerConfig RacingControllerConfig(const World& world) { return world.racingConfig; }
+
 private:
     static void SetVehiclePose(World& world, VehicleDynamics& dynamics, float x, float y, float z) {
         VehicleState state = dynamics.state();


### PR DESCRIPTION
## Summary
- move world runtime constants into configs/sim/world.yaml
- add a WorldConfigLoader that validates and loads world configuration values
- cover defaults and runtime application with new world configuration tests

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692440bb458c8324ac4a14e239db2d83)