### PR TITLE
Add world debug packet publisher

### DIFF
--- a/docs/architecture/boundary-sequence.md
+++ b/docs/architecture/boundary-sequence.md
@@ -15,7 +15,8 @@ sequenceDiagram
     IO->>World: publish_ground_truth(world)
     World->>Dyn: set_command(throttle, brake, steer)
     Dyn-->>World: state(), transform(), wheels_info()
-    World-->>IO: ground_truth_detections(), vehicle_state()
+    World-->>IO: vehicle_state(), track geometry
+    World-->>IO: publish_debug_packet(WorldDebugPacket)
     IO-->>Control: latest_raw_telemetry()
 ```
 
@@ -32,7 +33,8 @@ sequenceDiagram
     IO->>World: publish_ground_truth(world)
     World->>Dyn: set_command(throttle, brake, steer)
     Dyn-->>World: state(), transform(), wheels_info()
-    World-->>IO: ground_truth_detections(), vehicle_state()
+    World-->>IO: vehicle_state(), track geometry
+    World-->>IO: publish_debug_packet(WorldDebugPacket)
     IO->>IO: set_noise_config(TelemetryNoiseConfig)
     IO-->>Control: latest_noisy_telemetry(), latest_stereo_frame()
 ```

--- a/docs/architecture/simulation-data.md
+++ b/docs/architecture/simulation-data.md
@@ -14,7 +14,7 @@
 
 ## Public getters consumed by GUI/control (`sim/app/fsai_run.cpp`)
 
-* Rendering pulls cones, checkpoints, lookahead indices, vehicle pose, and detection overlays directly from the `World` getters for draw calls.【F:sim/app/fsai_run.cpp†L1322-L1465】
+* Rendering pulls cones, checkpoints, lookahead indices, and vehicle pose directly from the `World` getters for draw calls, while debug overlays (detections, controller path) flow through the IO debug channel.【F:sim/src/world/WorldRenderAdapter.cpp†L141-L240】【F:sim/app/fsai_run.cpp†L2565-L2597】
 * Control loop reads and optionally overrides `World` control fields (`throttleInput`, `brakeInput`, `steeringAngle`), invokes `computeRacingControl`, writes the neutral inputs back, and drives `VehicleDynamics::setCommand` before `World::update` consumes them.【F:sim/app/fsai_run.cpp†L2189-L2321】
 * Runtime telemetry populates GUI/control panels using `World` getters for lap timing, distance, mission progress, and mission descriptors.【F:sim/app/fsai_run.cpp†L2247-L2291】
 
@@ -26,6 +26,6 @@
 
 ## Surfaces that should be private/mediated
 
-* Mutable `World` fields (`throttleInput`, `brakeInput`, `steeringAngle`, `coneDetections`, `bestPathEdges`, `useController`, `regenTrack`) are public and written by UI/control code, bypassing validation or mission state checks.【F:sim/include/sim/World.hpp†L51-L58】【F:sim/app/fsai_run.cpp†L2189-L2316】
-* Geometry accessors expose mutable vectors (cones, checkpoints) used for rendering and path planning; callers could hold stale references across resets/regenerations.【F:sim/include/sim/World.hpp†L61-L115】【F:sim/app/fsai_run.cpp†L1322-L1465】
+* Mutable `World` fields (`throttleInput`, `brakeInput`, `steeringAngle`, `useController`, `regenTrack`) are public and written by UI/control code, bypassing validation or mission state checks.【F:sim/include/sim/World.hpp†L50-L56】【F:sim/app/fsai_run.cpp†L2179-L2325】
+* Geometry accessors expose mutable vectors (cones, checkpoints) used for rendering and path planning; callers could hold stale references across resets/regenerations.【F:sim/include/sim/World.hpp†L60-L114】【F:sim/app/gui_world_adapter.cpp†L5-L18】
 * Telemetry uses authoritative `World` state, but S-VCU transmissions build on noisy sensor facades; separating “truth” from “telemetry” producers would clarify which consumers should see which feed.【F:sim/app/fsai_run.cpp†L2230-L2291】【F:sim/app/fsai_run.cpp†L2391-L2479】

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -1709,6 +1709,7 @@ int main(int argc, char* argv[]) {
   const VehicleParam vehicle_param = VehicleParam::loadFromFile(vehicle_config_path.c_str());
   VehicleDynamics vehicle_dynamics(vehicle_param);
   World world;
+  world.set_debug_publisher(io_bus.get());
   bool mission_finished = false;
   const auto describe_reset_reason = [](fsai::sim::WorldRuntime::ResetReason reason)
       -> const char* {
@@ -2594,11 +2595,12 @@ int main(int argc, char* argv[]) {
       exit(-1);
     }
     auto detections = detection_buffer->tryPop();
+    std::vector<FsaiConeDet> debug_detections;
     if (detections != std::nullopt) {
-        for (int i = 0; i < detections->n; i++) {
-          world.coneDetections.push_back(detections->dets[i]);
-      }
+        debug_detections.assign(detections->dets, detections->dets + detections->n);
     }
+    world.set_debug_detections(std::move(debug_detections));
+    world.publish_debug_state();
 
     renderer.Render(now_ns, runtime_telemetry);
     if (imgui_initialized) {

--- a/sim/app/gui_world_adapter.cpp
+++ b/sim/app/gui_world_adapter.cpp
@@ -8,7 +8,6 @@ GuiWorldSnapshot GuiWorldAdapter::snapshot() const {
   snap.left_cones = world_.left_cones();
   snap.right_cones = world_.right_cones();
   snap.checkpoints = world_.checkpoint_positions();
-  snap.best_path_edges = world_.best_path_edges();
   snap.lookahead = world_.lookahead_indices();
   snap.vehicle_transform = world_.vehicle_transform();
   snap.vehicle_state = world_.vehicle_state();
@@ -17,7 +16,6 @@ GuiWorldSnapshot GuiWorldAdapter::snapshot() const {
   snap.total_distance_meters = world_.total_distance_meters();
   snap.time_step_seconds = world_.time_step_seconds();
   snap.lap_count = world_.lap_count();
-  snap.detections = &world_.ground_truth_detections();
   return snap;
 }
 

--- a/sim/app/gui_world_adapter.hpp
+++ b/sim/app/gui_world_adapter.hpp
@@ -16,7 +16,6 @@ struct GuiWorldSnapshot {
   std::vector<Vector3> left_cones;
   std::vector<Vector3> right_cones;
   std::vector<Vector3> checkpoints;
-  std::vector<std::pair<Vector2, Vector2>> best_path_edges;
   LookaheadIndices lookahead{};
   Transform vehicle_transform{};
   VehicleState vehicle_state{};
@@ -25,7 +24,6 @@ struct GuiWorldSnapshot {
   double total_distance_meters{0.0};
   double time_step_seconds{0.0};
   int lap_count{0};
-  const std::vector<FsaiConeDet>* detections{nullptr};
 };
 
 class GuiWorldAdapter {

--- a/sim/include/sim/architecture/IWorldView.hpp
+++ b/sim/include/sim/architecture/IWorldView.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 #include "MissionRuntimeState.hpp"
@@ -33,17 +32,12 @@ class IWorldView {
   virtual const std::vector<Vector3>& left_cones() const = 0;
   virtual const std::vector<Vector3>& right_cones() const = 0;
   virtual const LookaheadIndices& lookahead_indices() const = 0;
-  virtual const std::vector<std::pair<Vector2, Vector2>>& best_path_edges() const = 0;
-
   // --- Mission/runtime bookkeeping ---
   virtual const fsai::sim::MissionRuntimeState& mission_runtime() const = 0;
   virtual double lap_time_seconds() const = 0;
   virtual double total_distance_meters() const = 0;
   virtual double time_step_seconds() const = 0;
   virtual int lap_count() const = 0;
-
-  // --- Sensor/vision ground truth ---
-  virtual const std::vector<FsaiConeDet>& ground_truth_detections() const = 0;
 
   // --- Lifecycle helpers for consumers holding stale state ---
   virtual bool vehicle_reset_pending() const = 0;

--- a/sim/include/sim/architecture/WorldDebug.hpp
+++ b/sim/include/sim/architecture/WorldDebug.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "Vector.h"
+#include "common/types.h"
+
+namespace fsai::world {
+
+struct WorldDebugPacket {
+  std::vector<Vector3> start_cones;
+  std::vector<Vector3> left_cones;
+  std::vector<Vector3> right_cones;
+  std::vector<Vector3> checkpoints;
+  std::vector<std::pair<Vector2, Vector2>> controller_path_edges;
+  std::vector<FsaiConeDet> detections;
+};
+
+class IWorldDebugPublisher {
+ public:
+  virtual ~IWorldDebugPublisher() = default;
+  virtual void publish_debug_packet(const WorldDebugPacket& packet) = 0;
+};
+
+}  // namespace fsai::world
+

--- a/sim/src/io_bus.cpp
+++ b/sim/src/io_bus.cpp
@@ -27,6 +27,10 @@ void InProcessIoBus::set_telemetry_sink(TelemetrySink sink) {
 
 void InProcessIoBus::set_stereo_sink(StereoSink sink) { stereo_sink_ = std::move(sink); }
 
+void InProcessIoBus::set_debug_sink(WorldDebugSink sink) {
+  debug_sink_ = std::move(sink);
+}
+
 fsai::sim::svcu::TelemetryPacket InProcessIoBus::apply_noise(
     const fsai::sim::svcu::TelemetryPacket& raw) {
   fsai::sim::svcu::TelemetryPacket noisy = raw;
@@ -81,6 +85,18 @@ void InProcessIoBus::publish_stereo_frame(const FsaiStereoFrame& frame) {
 }
 
 std::optional<FsaiStereoFrame> InProcessIoBus::latest_stereo_frame() { return last_frame_; }
+
+void InProcessIoBus::publish_world_debug(
+    const fsai::world::WorldDebugPacket& packet) {
+  last_debug_ = packet;
+  if (debug_sink_) {
+    debug_sink_(packet);
+  }
+}
+
+std::optional<fsai::world::WorldDebugPacket> InProcessIoBus::latest_world_debug() {
+  return last_debug_;
+}
 
 }  // namespace fsai::io
 

--- a/sim/src/world/WorldRenderAdapter.hpp
+++ b/sim/src/world/WorldRenderAdapter.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <SDL.h>
@@ -12,6 +13,7 @@
 #include "io_bus.hpp"
 #include "runtime_telemetry.hpp"
 #include "sim/architecture/IWorldView.hpp"
+#include "sim/architecture/WorldDebug.hpp"
 
 namespace fsai::io::camera::sim_stereo {
 class SimStereoSource;
@@ -48,7 +50,8 @@ class WorldRenderAdapter {
 
  private:
   void drawScene(const fsai::sim::app::GuiWorldSnapshot& snapshot,
-                 const fsai::sim::app::RuntimeTelemetry& telemetry);
+                 const fsai::sim::app::RuntimeTelemetry& telemetry,
+                 const std::optional<fsai::world::WorldDebugPacket>& debug_packet);
   void publishStereoFrame(const fsai::sim::app::GuiWorldSnapshot& snapshot,
                           uint64_t now_ns);
 


### PR DESCRIPTION
## Summary
- add a WorldDebugPacket interface and route it through the IO bus for debug consumers
- publish world debug overlays instead of exposing mutable vectors and render them via the adapter
- update documentation to reflect the new debug channel and restricted world surface area

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ff5a8f9883249a3d004b14e37df0)