### PR TITLE
Add subsystem flow comments for simulator integration

### DIFF
--- a/sim/src/io_bus.cpp
+++ b/sim/src/io_bus.cpp
@@ -2,6 +2,13 @@
 
 #include <cmath>
 
+// IO SUBSYSTEM: InProcessIoBus glues simulated telemetry, commands, and stereo
+// frames together inside a single process. The agent publishes ground-truth
+// telemetry from Vehicle Dynamics into this bus, optionally adds noise, then
+// fans it out to the Control and Vision frontends via callbacks or buffered
+// reads. The same object also carries Control commands back into the sim and
+// Vision stereo frames into the Vision pipeline.
+
 namespace fsai::io {
 namespace {
 
@@ -33,6 +40,9 @@ void InProcessIoBus::set_debug_sink(WorldDebugSink sink) {
 
 fsai::sim::svcu::TelemetryPacket InProcessIoBus::apply_noise(
     const fsai::sim::svcu::TelemetryPacket& raw) {
+  // BACKEND NOISE MODEL: perturb ground-truth telemetry before sending it to
+  // the Control/Vision consumers to approximate realistic sensors. All values
+  // are zeroed today but the plumbing is ready for future tuning.
   fsai::sim::svcu::TelemetryPacket noisy = raw;
   noisy.steer_angle_rad += static_cast<float>(sample_noise(rng_, noise_.steer_rad_stddev));
   noisy.front_axle_torque_nm +=
@@ -56,6 +66,9 @@ fsai::sim::svcu::TelemetryPacket InProcessIoBus::apply_noise(
 void InProcessIoBus::publish_telemetry(const fsai::sim::svcu::TelemetryPacket& raw) {
   raw_telemetry_ = raw;
   noisy_telemetry_ = apply_noise(raw);
+  // IO->CONTROL/VISION: push the noisy packet downstream via the optional
+  // callback hook (used by Control) while keeping the latest copy for GUI
+  // panels and Vision side reads.
   if (telemetry_sink_) {
     telemetry_sink_(*noisy_telemetry_);
   }
@@ -70,6 +83,8 @@ std::optional<fsai::sim::svcu::TelemetryPacket> InProcessIoBus::latest_noisy_tel
 }
 
 void InProcessIoBus::push_command(const fsai::sim::svcu::CommandPacket& cmd) {
+  // CONTROL->IO->VEHICLE: enqueue the latest actuator command so the vehicle
+  // dynamics adapter can pick it up on the next tick.
   latest_command_ = cmd;
 }
 
@@ -79,6 +94,8 @@ std::optional<fsai::sim::svcu::CommandPacket> InProcessIoBus::latest_command() {
 
 void InProcessIoBus::publish_stereo_frame(const FsaiStereoFrame& frame) {
   last_frame_ = frame;
+  // WORLD/GRAPHICS->VISION: forward simulated stereo images into the Vision
+  // frame ring buffer or previews to keep the perception pipeline fed.
   if (stereo_sink_) {
     stereo_sink_(frame);
   }
@@ -89,6 +106,9 @@ std::optional<FsaiStereoFrame> InProcessIoBus::latest_stereo_frame() { return la
 void InProcessIoBus::publish_world_debug(
     const fsai::world::WorldDebugPacket& packet) {
   last_debug_ = packet;
+  // WORLD->IO->VISION/CONTROL: broadcast debug overlays (ground truth cones,
+  // controller path, detections) so both the GUI and downstream systems can
+  // visualize shared context.
   if (debug_sink_) {
     debug_sink_(packet);
   }

--- a/sim/src/world/WorldRenderAdapter.cpp
+++ b/sim/src/world/WorldRenderAdapter.cpp
@@ -56,6 +56,9 @@ void DrawCheckpointSquare(Graphics* graphics, int center_x, int center_y,
 }
 }  // namespace
 
+// WORLD RENDERER: owns the graphics window, pushes stereo frames into Vision,
+// and reads live World snapshots + IO debug packets so the GUI can annotate
+// ground truth, detections, and controller state in one place.
 WorldRenderAdapter::WorldRenderAdapter(const WorldRendererConfig& config,
                                        const fsai::world::IWorldView& world_view,
                                        fsai::io::IoBus& io_bus)
@@ -128,6 +131,9 @@ void WorldRenderAdapter::Render(
     return;
   }
 
+  // RENDER PASS: capture a consistent snapshot from the WorldView and combine
+  // it with any IO-provided debug overlays (e.g., Control/Vision annotations)
+  // before drawing the GUI or pushing stereo frames.
   const auto snapshot = gui_adapter_.snapshot();
   const auto debug_packet = io_bus_.latest_world_debug();
   if (window_initialized_) {


### PR DESCRIPTION
## Summary
- document mission setup, world/vision/IO wiring, and reset handling in `fsai_run.cpp`
- add flow notes to the World subsystem and render adapter to explain data paths
- describe IO bus responsibilities for telemetry, commands, and stereo frames

## Testing
- No automated tests were run (comments-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925811c865c832497d61b31636b9cae)