### PR TITLE
Fix telemetry include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ list(APPEND HEADER_DIRS
   "${CMAKE_SOURCE_DIR}/sim/include"
   "${CMAKE_SOURCE_DIR}/vision/runtime_cpp/include"
   "${CMAKE_SOURCE_DIR}/vision_test/runtime_cpp/include"
+  "${CMAKE_SOURCE_DIR}/velox/lib"
 )
 list(REMOVE_DUPLICATES HEADER_DIRS)
 

--- a/common/src/telemetry/telemetry.cpp
+++ b/common/src/telemetry/telemetry.cpp
@@ -1,4 +1,4 @@
-#include "telemetry/telemetry.hpp"
+#include <telemetry/telemetry.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/sim/include/simulation/simulation_daemon.hpp
+++ b/sim/include/simulation/simulation_daemon.hpp
@@ -13,7 +13,7 @@
 #include "simulation/low_speed_safety.hpp"
 #include "simulation/model_timing.hpp"
 #include "simulation/vehicle_simulator.hpp"
-#include "telemetry/telemetry.hpp"
+#include <telemetry/telemetry.hpp>
 #include "simulation/user_input.hpp"
 
 namespace velox::simulation {

--- a/sim/src/simulation/simulation_daemon.cpp
+++ b/sim/src/simulation/simulation_daemon.cpp
@@ -1,4 +1,5 @@
 #include "simulation/simulation_daemon.hpp"
+#include <telemetry/telemetry.hpp>
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
## Summary
- point telemetry includes to the lowercase velox header
- add the velox/lib directory to the project include paths so relocated telemetry headers are found

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e69da4d0832485d288a0982a836f)