### PR TITLE
Fix telemetry namespace usage in SimulationDaemon

### DIFF
--- a/sim/include/simulation/simulation_daemon.hpp
+++ b/sim/include/simulation/simulation_daemon.hpp
@@ -18,6 +18,8 @@
 
 namespace velox::simulation {
 
+using telemetry = velox::telemetry;
+
 struct ResetParams {
     std::optional<ModelType> model{};
     std::optional<int>       vehicle_id{};

--- a/sim/src/simulation/simulation_daemon.cpp
+++ b/sim/src/simulation/simulation_daemon.cpp
@@ -18,6 +18,8 @@
 
 namespace velox::simulation {
 
+using telemetry = ::velox::telemetry;
+
 UserInputLimits UserInputLimits::from_vehicle(const controllers::SteeringWheel* steering_wheel,
                                               const controllers::FinalSteerController* final_steer,
                                               const models::VehicleParameters& params,


### PR DESCRIPTION
## Summary
- add alias to resolve velox telemetry namespace in SimulationDaemon interface and implementation
- ensure snapshot and step return types reference the resolved SimulationTelemetry type

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e7f579ac8324aecb1a92d2e78fc3)