### PR TITLE
Fix include casing for Velox vehicle dynamics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ target_include_directories(fsai_run PRIVATE
     "${CMAKE_SOURCE_DIR}/vision_test/runtime_cpp/src"
     "${CMAKE_SOURCE_DIR}/vision_test/runtime_cpp/include"
     "${CMAKE_SOURCE_DIR}/common/include"
+    "${CMAKE_SOURCE_DIR}/sim/include"
 )
 target_compile_definitions(fsai_run PRIVATE FSAI_PROJECT_ROOT="${CMAKE_SOURCE_DIR}")
 target_link_libraries(fsai_run PRIVATE fsai_sim fsai_rendering imgui)

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -48,7 +48,7 @@
 #include "types.h"
 #include "World.hpp"
 #include "WorldRenderAdapter.hpp"
-#include "VeloxVehicleDynamics.hpp"
+#include "sim/vehicle/VeloxVehicleDynamics.hpp"
 #include "sim/mission/MissionDefinition.hpp"
 #include "sim/mission/TrackCsvLoader.hpp"
 #include "adsdv_dbc.hpp"


### PR DESCRIPTION
## Summary
- include the Velox vehicle dynamics header using its exact path and casing
- expose sim/include explicitly to the fsai_run target for case-sensitive builds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ed4088508324bd34fe5c18e18bce)