### PR TITLE
Include unified logging header for vision node

### DIFF
--- a/vision/runtime_cpp/src/vision_node.cpp
+++ b/vision/runtime_cpp/src/vision_node.cpp
@@ -5,7 +5,7 @@
  * Calculate glob coordinate
  */
 #include "vision/vision_node.hpp"
-#include "logging.hpp"
+#include "sim/include/logging.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>


### PR DESCRIPTION
## Summary
- include the shared logging header in the vision runtime node implementation

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f00c33dc83249d7a291d97b526b1)