### PR TITLE
Clarify sim logging includes

### DIFF
--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -36,7 +36,7 @@
 #include "budget.h"
 #include "fsai_clock.h"
 #include "csv_logger.hpp"
-#include "logging.hpp"
+#include "sim/include/logging.hpp"
 #include "stereo_display.hpp"
 #include "edge_preview.hpp"
 #include "vision/frame_ring_buffer.hpp"

--- a/sim/src/integration/stereo_display.cpp
+++ b/sim/src/integration/stereo_display.cpp
@@ -1,6 +1,6 @@
 #include "stereo_display.hpp"
 
-#include "logging.hpp"
+#include "sim/include/logging.hpp"
 
 #include <cstdio>
 

--- a/sim/src/logging.cpp
+++ b/sim/src/logging.cpp
@@ -1,4 +1,4 @@
-#include "logging.hpp"
+#include "sim/include/logging.hpp"
 
 #include <chrono>
 #include <cstdarg>

--- a/sim/src/world/WorldRenderAdapter.cpp
+++ b/sim/src/world/WorldRenderAdapter.cpp
@@ -1,6 +1,6 @@
 #include "WorldRenderAdapter.hpp"
 
-#include "logging.hpp"
+#include "sim/include/logging.hpp"
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
## Summary
- use the namespaced sim logger include path to avoid conflicts with common logging headers
- update sim components to include the logger via the explicit sim path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69265114ff808324b2f9cd0727480b6c)