### PR TITLE
Align telemetry includes and namespaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,9 +174,9 @@ foreach(h ${ALL_HEADERS})
     list(APPEND HEADER_DIRS "${hdir}")
   endif()
 endforeach()
+list(PREPEND HEADER_DIRS "${CMAKE_SOURCE_DIR}/common/include")
 list(APPEND HEADER_DIRS "${CMAKE_SOURCE_DIR}/third_party/glad/include")
 list(APPEND HEADER_DIRS
-  "${CMAKE_SOURCE_DIR}/common/include"
   "${CMAKE_SOURCE_DIR}/control/include"
   "${CMAKE_SOURCE_DIR}/io/include"
   "${CMAKE_SOURCE_DIR}/sim/include"
@@ -191,6 +191,7 @@ list(REMOVE_DUPLICATES HEADER_DIRS)
 # ------------------------------------------------------------------------------
 add_subdirectory(vision_test/runtime_cpp/src)
 target_include_directories(fsai_vision_runtime PUBLIC
+    "${CMAKE_SOURCE_DIR}/common/include"
     "${CMAKE_SOURCE_DIR}/vision/runtime_cpp/include"
     "${CMAKE_SOURCE_DIR}"
 
@@ -327,11 +328,11 @@ file(GLOB_RECURSE SIM_APP_SOURCES CONFIGURE_DEPENDS
 )
 add_executable(fsai_run ${SIM_APP_SOURCES})
 target_include_directories(fsai_run PRIVATE
+    "${CMAKE_SOURCE_DIR}/common/include"
     "${CMAKE_SOURCE_DIR}/vision/runtime_cpp/include"
     "${CMAKE_SOURCE_DIR}"
     "${CMAKE_SOURCE_DIR}/vision_test/runtime_cpp/src"
     "${CMAKE_SOURCE_DIR}/vision_test/runtime_cpp/include"
-    "${CMAKE_SOURCE_DIR}/common/include"
     "${CMAKE_SOURCE_DIR}/sim/include"
 )
 target_compile_definitions(fsai_run PRIVATE FSAI_PROJECT_ROOT="${CMAKE_SOURCE_DIR}")

--- a/common/include/telemetry/telemetry.hpp
+++ b/common/include/telemetry/telemetry.hpp
@@ -100,26 +100,26 @@ struct SimulationTelemetry {
     AxleTelemetry         rear_axle{};
     DerivedTelemetry      totals{};
     double                detector_severity{0.0};
-    simulation::SafetyStage safety_stage{simulation::SafetyStage::Normal};
+    velox::simulation::SafetyStage safety_stage{velox::simulation::SafetyStage::Normal};
     bool                  detector_forced{false};
     bool                  low_speed_engaged{false};
 };
 
 SimulationTelemetry compute_simulation_telemetry(
-    simulation::ModelType model,
+    velox::simulation::ModelType model,
     const models::VehicleParameters& params,
     const std::vector<double>& state,
     const controllers::longitudinal::ControllerOutput& accel_output,
     const controllers::SteeringWheel::Output& steering_wheel_output,
     const controllers::FinalSteerController::Output& steering_output,
-    const simulation::LowSpeedSafety* safety,
+    const velox::simulation::LowSpeedSafety* safety,
     double measured_speed,
     double cumulative_distance_m,
     double cumulative_energy_j,
     double cumulative_sim_time_s);
 
 std::string to_json(const SimulationTelemetry& telemetry);
-const char*  safety_stage_to_string(simulation::SafetyStage stage);
+const char*  safety_stage_to_string(velox::simulation::SafetyStage stage);
 
 } // namespace velox::telemetry
 

--- a/common/src/telemetry/telemetry.cpp
+++ b/common/src/telemetry/telemetry.cpp
@@ -1,4 +1,4 @@
-#include <telemetry/telemetry.hpp>
+#include "telemetry/telemetry.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -12,16 +12,16 @@ namespace {
 constexpr double kGravity = 9.81;
 constexpr double kEpsilon = 1e-6;
 
-double yaw_rate_from_state(simulation::ModelType model, const std::vector<double>& state, double v_long, double steer_angle, double wheelbase)
+double yaw_rate_from_state(velox::simulation::ModelType model, const std::vector<double>& state, double v_long, double steer_angle, double wheelbase)
 {
     (void)v_long;
     (void)steer_angle;
     (void)wheelbase;
 
     switch (model) {
-        case simulation::ModelType::ST:
-        case simulation::ModelType::STD:
-        case simulation::ModelType::MB:
+        case velox::simulation::ModelType::ST:
+        case velox::simulation::ModelType::STD:
+        case velox::simulation::ModelType::MB:
             if (state.size() > 5) {
                 return state[5];
             }
@@ -37,14 +37,14 @@ double axle_slip_angle(double v_lat, double v_long, double yaw_rate, double offs
     return std::atan2(lateral_velocity, safe_longitudinal) - steer_angle;
 }
 
-const char* safety_stage_name(simulation::SafetyStage stage)
+const char* safety_stage_name(velox::simulation::SafetyStage stage)
 {
     switch (stage) {
-        case simulation::SafetyStage::Normal:
+        case velox::simulation::SafetyStage::Normal:
             return "normal";
-        case simulation::SafetyStage::Transition:
+        case velox::simulation::SafetyStage::Transition:
             return "transition";
-        case simulation::SafetyStage::Emergency:
+        case velox::simulation::SafetyStage::Emergency:
             return "emergency";
     }
     return "unknown";
@@ -108,13 +108,13 @@ void populate_axle(AxleTelemetry& axle,
 } // namespace
 
 SimulationTelemetry compute_simulation_telemetry(
-    simulation::ModelType model,
+    velox::simulation::ModelType model,
     const models::VehicleParameters& params,
     const std::vector<double>& state,
     const controllers::longitudinal::ControllerOutput& accel_output,
     const controllers::SteeringWheel::Output& steering_wheel_output,
     const controllers::FinalSteerController::Output& steering_output,
-    const simulation::LowSpeedSafety* safety,
+    const velox::simulation::LowSpeedSafety* safety,
     double measured_speed,
     double cumulative_distance_m,
     double cumulative_energy_j,
@@ -131,7 +131,7 @@ SimulationTelemetry compute_simulation_telemetry(
     double beta   = 0.0;
 
     switch (model) {
-        case simulation::ModelType::ST:
+        case velox::simulation::ModelType::ST:
             if (state.size() >= 7) {
                 v_long = state[3];
                 yaw    = state[4];
@@ -139,7 +139,7 @@ SimulationTelemetry compute_simulation_telemetry(
             }
             break;
 
-        case simulation::ModelType::STD:
+        case velox::simulation::ModelType::STD:
             if (state.size() >= 9) {
                 v_long = state[3];
                 yaw    = state[4];
@@ -147,7 +147,7 @@ SimulationTelemetry compute_simulation_telemetry(
             }
             break;
 
-        case simulation::ModelType::MB:
+        case velox::simulation::ModelType::MB:
             if (state.size() >= 11) {
                 v_long = state[3];
                 v_lat  = state[10];
@@ -178,13 +178,13 @@ SimulationTelemetry compute_simulation_telemetry(
 
     telemetry.acceleration.longitudinal = accel_output.acceleration;
     switch (model) {
-        case simulation::ModelType::MB:
+        case velox::simulation::ModelType::MB:
             if (state.size() > 5) {
                 telemetry.acceleration.lateral = v_long * state[5];
             }
             break;
-        case simulation::ModelType::ST:
-        case simulation::ModelType::STD:
+        case velox::simulation::ModelType::ST:
+        case velox::simulation::ModelType::STD:
             if (state.size() > 5) {
                 telemetry.acceleration.lateral = v_long * state[5];
             }
@@ -288,7 +288,7 @@ SimulationTelemetry compute_simulation_telemetry(
     return telemetry;
 }
 
-const char* safety_stage_to_string(simulation::SafetyStage stage)
+const char* safety_stage_to_string(velox::simulation::SafetyStage stage)
 {
     return safety_stage_name(stage);
 }

--- a/sim/include/simulation/simulation_daemon.hpp
+++ b/sim/include/simulation/simulation_daemon.hpp
@@ -13,7 +13,7 @@
 #include "simulation/low_speed_safety.hpp"
 #include "simulation/model_timing.hpp"
 #include "simulation/vehicle_simulator.hpp"
-#include <telemetry/telemetry.hpp>
+#include "telemetry/telemetry.hpp"
 #include "simulation/user_input.hpp"
 
 namespace velox::simulation {

--- a/sim/src/simulation/simulation_daemon.cpp
+++ b/sim/src/simulation/simulation_daemon.cpp
@@ -1,5 +1,5 @@
 #include "simulation/simulation_daemon.hpp"
-#include <telemetry/telemetry.hpp>
+#include "telemetry/telemetry.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/velox/lib/telemetry/telemetry.cpp
+++ b/velox/lib/telemetry/telemetry.cpp
@@ -12,16 +12,16 @@ namespace {
 constexpr double kGravity = 9.81;
 constexpr double kEpsilon = 1e-6;
 
-double yaw_rate_from_state(simulation::ModelType model, const std::vector<double>& state, double v_long, double steer_angle, double wheelbase)
+double yaw_rate_from_state(velox::simulation::ModelType model, const std::vector<double>& state, double v_long, double steer_angle, double wheelbase)
 {
     (void)v_long;
     (void)steer_angle;
     (void)wheelbase;
 
     switch (model) {
-        case simulation::ModelType::ST:
-        case simulation::ModelType::STD:
-        case simulation::ModelType::MB:
+        case velox::simulation::ModelType::ST:
+        case velox::simulation::ModelType::STD:
+        case velox::simulation::ModelType::MB:
             if (state.size() > 5) {
                 return state[5];
             }
@@ -37,14 +37,14 @@ double axle_slip_angle(double v_lat, double v_long, double yaw_rate, double offs
     return std::atan2(lateral_velocity, safe_longitudinal) - steer_angle;
 }
 
-const char* safety_stage_name(simulation::SafetyStage stage)
+const char* safety_stage_name(velox::simulation::SafetyStage stage)
 {
     switch (stage) {
-        case simulation::SafetyStage::Normal:
+        case velox::simulation::SafetyStage::Normal:
             return "normal";
-        case simulation::SafetyStage::Transition:
+        case velox::simulation::SafetyStage::Transition:
             return "transition";
-        case simulation::SafetyStage::Emergency:
+        case velox::simulation::SafetyStage::Emergency:
             return "emergency";
     }
     return "unknown";
@@ -108,13 +108,13 @@ void populate_axle(AxleTelemetry& axle,
 } // namespace
 
 SimulationTelemetry compute_simulation_telemetry(
-    simulation::ModelType model,
+    velox::simulation::ModelType model,
     const models::VehicleParameters& params,
     const std::vector<double>& state,
     const controllers::longitudinal::ControllerOutput& accel_output,
     const controllers::SteeringWheel::Output& steering_wheel_output,
     const controllers::FinalSteerController::Output& steering_output,
-    const simulation::LowSpeedSafety* safety,
+    const velox::simulation::LowSpeedSafety* safety,
     double measured_speed,
     double cumulative_distance_m,
     double cumulative_energy_j,
@@ -131,7 +131,7 @@ SimulationTelemetry compute_simulation_telemetry(
     double beta   = 0.0;
 
     switch (model) {
-        case simulation::ModelType::ST:
+        case velox::simulation::ModelType::ST:
             if (state.size() >= 7) {
                 v_long = state[3];
                 yaw    = state[4];
@@ -139,7 +139,7 @@ SimulationTelemetry compute_simulation_telemetry(
             }
             break;
 
-        case simulation::ModelType::STD:
+        case velox::simulation::ModelType::STD:
             if (state.size() >= 9) {
                 v_long = state[3];
                 yaw    = state[4];
@@ -147,7 +147,7 @@ SimulationTelemetry compute_simulation_telemetry(
             }
             break;
 
-        case simulation::ModelType::MB:
+        case velox::simulation::ModelType::MB:
             if (state.size() >= 11) {
                 v_long = state[3];
                 v_lat  = state[10];
@@ -178,13 +178,13 @@ SimulationTelemetry compute_simulation_telemetry(
 
     telemetry.acceleration.longitudinal = accel_output.acceleration;
     switch (model) {
-        case simulation::ModelType::MB:
+        case velox::simulation::ModelType::MB:
             if (state.size() > 5) {
                 telemetry.acceleration.lateral = v_long * state[5];
             }
             break;
-        case simulation::ModelType::ST:
-        case simulation::ModelType::STD:
+        case velox::simulation::ModelType::ST:
+        case velox::simulation::ModelType::STD:
             if (state.size() > 5) {
                 telemetry.acceleration.lateral = v_long * state[5];
             }
@@ -288,7 +288,7 @@ SimulationTelemetry compute_simulation_telemetry(
     return telemetry;
 }
 
-const char* safety_stage_to_string(simulation::SafetyStage stage)
+const char* safety_stage_to_string(velox::simulation::SafetyStage stage)
 {
     return safety_stage_name(stage);
 }

--- a/velox/lib/telemetry/telemetry.hpp
+++ b/velox/lib/telemetry/telemetry.hpp
@@ -100,26 +100,26 @@ struct SimulationTelemetry {
     AxleTelemetry         rear_axle{};
     DerivedTelemetry      totals{};
     double                detector_severity{0.0};
-    simulation::SafetyStage safety_stage{simulation::SafetyStage::Normal};
+    velox::simulation::SafetyStage safety_stage{velox::simulation::SafetyStage::Normal};
     bool                  detector_forced{false};
     bool                  low_speed_engaged{false};
 };
 
 SimulationTelemetry compute_simulation_telemetry(
-    simulation::ModelType model,
+    velox::simulation::ModelType model,
     const models::VehicleParameters& params,
     const std::vector<double>& state,
     const controllers::longitudinal::ControllerOutput& accel_output,
     const controllers::SteeringWheel::Output& steering_wheel_output,
     const controllers::FinalSteerController::Output& steering_output,
-    const simulation::LowSpeedSafety* safety,
+    const velox::simulation::LowSpeedSafety* safety,
     double measured_speed,
     double cumulative_distance_m,
     double cumulative_energy_j,
     double cumulative_sim_time_s);
 
 std::string to_json(const SimulationTelemetry& telemetry);
-const char*  safety_stage_to_string(simulation::SafetyStage stage);
+const char*  safety_stage_to_string(velox::simulation::SafetyStage stage);
 
 } // namespace velox::telemetry
 

--- a/vision_test/runtime_cpp/src/CMakeLists.txt
+++ b/vision_test/runtime_cpp/src/CMakeLists.txt
@@ -8,8 +8,8 @@ add_library(fsai_vision_runtime STATIC ${VISION_RUNTIME_SOURCES})
 
 target_include_directories(fsai_vision_runtime
   PUBLIC
-    ${CMAKE_SOURCE_DIR}/vision_test/runtime_cpp/include
     ${CMAKE_SOURCE_DIR}/common/include
+    ${CMAKE_SOURCE_DIR}/vision_test/runtime_cpp/include
     ${CMAKE_SOURCE_DIR}/common/include/common
     ${OpenCV_INCLUDE_DIRS}
     ${SDL2_INCLUDE_DIRS}


### PR DESCRIPTION
## Summary
- switch telemetry includes to project-relative headers and qualify telemetry types under velox::simulation
- ensure common/include appears first in include search paths for relevant targets to prioritize Velox telemetry definitions
- update vision and simulation targets to reference the adjusted headers consistently

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692651fb0a348324858aaa13cdccf9a8)