### PR TITLE
Fully qualify telemetry references in SimulationDaemon

### DIFF
--- a/sim/include/simulation/simulation_daemon.hpp
+++ b/sim/include/simulation/simulation_daemon.hpp
@@ -17,9 +17,6 @@
 #include "simulation/user_input.hpp"
 
 namespace velox::simulation {
-
-using telemetry = velox::telemetry;
-
 struct ResetParams {
     std::optional<ModelType> model{};
     std::optional<int>       vehicle_id{};
@@ -30,10 +27,10 @@ struct ResetParams {
 };
 
 struct SimulationSnapshot {
-    std::vector<double>               state{};
-    telemetry::SimulationTelemetry    telemetry{};
-    double                            dt{0.0};
-    double                            simulation_time_s{0.0};
+    std::vector<double>                   state{};
+    ::velox::telemetry::SimulationTelemetry telemetry{};
+    double                                  dt{0.0};
+    double                                  simulation_time_s{0.0};
 };
 
     class SimulationDaemon {
@@ -61,8 +58,9 @@ struct SimulationSnapshot {
 
     void set_log_sink(logging::LogSinkPtr sink) { log_sink_ = std::move(sink); }
 
-    telemetry::SimulationTelemetry step(const UserInput& input);
-    std::vector<telemetry::SimulationTelemetry> step(const std::vector<UserInput>& batch_inputs);
+    ::velox::telemetry::SimulationTelemetry step(const UserInput& input);
+    std::vector<::velox::telemetry::SimulationTelemetry>
+        step(const std::vector<UserInput>& batch_inputs);
 
     [[nodiscard]] const VehicleSimulator* simulator() const { return simulator_.get(); }
     [[nodiscard]] const controllers::longitudinal::FinalAccelController* accel_controller() const
@@ -82,7 +80,10 @@ struct SimulationSnapshot {
     [[nodiscard]] bool drift_enabled() const { return drift_enabled_; }
     [[nodiscard]] ControlMode control_mode() const { return control_mode_; }
     void                set_drift_enabled(bool enabled);
-    [[nodiscard]] const telemetry::SimulationTelemetry& telemetry() const { return last_telemetry_; }
+    [[nodiscard]] const ::velox::telemetry::SimulationTelemetry& telemetry() const
+    {
+        return last_telemetry_;
+    }
 
     [[nodiscard]] SimulationSnapshot snapshot() const;
 
@@ -125,7 +126,7 @@ private:
     double cumulative_distance_m_{0.0};
     double cumulative_energy_j_{0.0};
 
-    telemetry::SimulationTelemetry last_telemetry_{};
+    ::velox::telemetry::SimulationTelemetry last_telemetry_{};
 
     void load_vehicle_parameters(int vehicle_id);
     void rebuild_controllers();
@@ -134,7 +135,7 @@ private:
     void rebuild_simulator(double dt, const std::vector<double>& initial_state);
     void rebuild_input_limits();
     double direct_acceleration_from_torque(const std::vector<double>& axle_torques) const;
-    telemetry::SimulationTelemetry compute_telemetry(
+    ::velox::telemetry::SimulationTelemetry compute_telemetry(
         const controllers::longitudinal::ControllerOutput& accel_output,
         const controllers::SteeringWheel::Output& steering_input,
         const controllers::FinalSteerController::Output&    steering_output) const;

--- a/sim/src/simulation/simulation_daemon.cpp
+++ b/sim/src/simulation/simulation_daemon.cpp
@@ -17,9 +17,6 @@
 #include "vehicle_parameters.hpp"
 
 namespace velox::simulation {
-
-using telemetry = ::velox::telemetry;
-
 UserInputLimits UserInputLimits::from_vehicle(const controllers::SteeringWheel* steering_wheel,
                                               const controllers::FinalSteerController* final_steer,
                                               const models::VehicleParameters& params,
@@ -384,7 +381,7 @@ void SimulationDaemon::reset(const ResetParams& params)
     }
 }
 
-telemetry::SimulationTelemetry SimulationDaemon::step(const UserInput& input)
+::velox::telemetry::SimulationTelemetry SimulationDaemon::step(const UserInput& input)
 {
     try {
         if (!simulator_ || !accel_controller_ || !steering_wheel_ || !final_steer_ || !safety_) {
@@ -487,9 +484,10 @@ void SimulationDaemon::set_drift_enabled(bool enabled)
     }
 }
 
-std::vector<telemetry::SimulationTelemetry> SimulationDaemon::step(const std::vector<UserInput>& batch_inputs)
+std::vector<::velox::telemetry::SimulationTelemetry>
+    SimulationDaemon::step(const std::vector<UserInput>& batch_inputs)
 {
-    std::vector<telemetry::SimulationTelemetry> telemetry;
+    std::vector<::velox::telemetry::SimulationTelemetry> telemetry;
     telemetry.reserve(batch_inputs.size());
     for (std::size_t i = 0; i < batch_inputs.size(); ++i) {
         try {
@@ -608,7 +606,7 @@ double SimulationDaemon::direct_acceleration_from_torque(const std::vector<doubl
     return total_torque / (params_.m * params_.R_w);
 }
 
-telemetry::SimulationTelemetry SimulationDaemon::compute_telemetry(
+::velox::telemetry::SimulationTelemetry SimulationDaemon::compute_telemetry(
     const controllers::longitudinal::ControllerOutput& accel_output,
     const controllers::SteeringWheel::Output& steering_input,
     const controllers::FinalSteerController::Output& steering_output) const
@@ -618,17 +616,17 @@ telemetry::SimulationTelemetry SimulationDaemon::compute_telemetry(
     const auto& state         = simulator_ptr ? simulator_ptr->state() : std::vector<double>{};
     const double measured_speed = simulator_ptr ? simulator_ptr->speed() : 0.0;
 
-    return telemetry::compute_simulation_telemetry(model_,
-                                                   params_,
-                                                   state,
-                                                   accel_output,
-                                                   steering_input,
-                                                   steering_output,
-                                                   safety_ptr,
-                                                   measured_speed,
-                                                   cumulative_distance_m_,
-                                                   cumulative_energy_j_,
-                                                   timing_.cumulative_time());
+    return ::velox::telemetry::compute_simulation_telemetry(model_,
+                                                            params_,
+                                                            state,
+                                                            accel_output,
+                                                            steering_input,
+                                                            steering_output,
+                                                            safety_ptr,
+                                                            measured_speed,
+                                                            cumulative_distance_m_,
+                                                            cumulative_energy_j_,
+                                                            timing_.cumulative_time());
 }
 
 void SimulationDaemon::log_warning(const std::string& message) const


### PR DESCRIPTION
## Summary
- remove the telemetry alias from SimulationDaemon and use fully qualified velox::telemetry types
- update SimulationSnapshot, step methods, and telemetry computation signatures to match
- ensure implementation uses qualified telemetry helpers without reintroducing conflicting aliases

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692653727ac88324954bf66b367427e6)