### PR TITLE
Link telemetry into fsai_run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ target_include_directories(fsai_run PRIVATE
     "${CMAKE_SOURCE_DIR}/sim/include"
 )
 target_compile_definitions(fsai_run PRIVATE FSAI_PROJECT_ROOT="${CMAKE_SOURCE_DIR}")
-target_link_libraries(fsai_run PRIVATE fsai_sim fsai_rendering imgui)
+target_link_libraries(fsai_run PRIVATE fsai_sim fsai_rendering imgui fsai_telemetry)
 if(TARGET fsai_vision_runtime)
   target_link_libraries(fsai_run PRIVATE fsai_vision_runtime)
 endif()


### PR DESCRIPTION
## Summary
- link the fsai_telemetry library directly into the fsai_run executable to ensure telemetry symbols are available at link time

## Testing
- ./build.sh *(fails: Eigen3 package configuration not found in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69271b391f188324aa3a5a3aff403d02)