### PR TITLE
Link control runtime against telemetry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,7 @@ file(GLOB_RECURSE CONTROL_RUNTIME_SOURCES CONFIGURE_DEPENDS
 if(CONTROL_RUNTIME_SOURCES)
   add_library(fsai_control_runtime STATIC ${CONTROL_RUNTIME_SOURCES})
   target_include_directories(fsai_control_runtime PUBLIC ${HEADER_DIRS})
-  target_link_libraries(fsai_control_runtime PUBLIC fsai_sim)
+  target_link_libraries(fsai_control_runtime PUBLIC fsai_sim fsai_telemetry)
   if(UNIX)
     target_link_libraries(fsai_control_runtime PUBLIC dl)
   endif()


### PR DESCRIPTION
## Summary
- link fsai_control_runtime against fsai_telemetry so telemetry symbols propagate transitively to fsai_run

## Testing
- cmake -S . -B build *(fails: Eigen3 package configuration not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69271d84a9bc8324ad227d64b7ebfa54)