### PR TITLE
Add ADS-DV EV Velox parameters and selection

### DIFF
--- a/configs/vehicle/configDry.yaml
+++ b/configs/vehicle/configDry.yaml
@@ -72,6 +72,10 @@ input_ranges:
     max: 0.3665191
     min: -0.3665191
 
+velox:
+  model: st
+  vehicle_id: 5
+
 physics:
   h_cg: 0.25       # m
   c_rr: 0.012      # rolling resistance coefficient

--- a/sim/app/fsai_run.cpp
+++ b/sim/app/fsai_run.cpp
@@ -1725,6 +1725,19 @@ int main(int argc, char* argv[]) {
   fsai::vehicle::VeloxVehicleDynamics::Config dynamics_cfg{};
   dynamics_cfg.config_root = MakeProjectRelativePath(std::filesystem::path("velox/config"));
   dynamics_cfg.parameter_root = MakeProjectRelativePath(std::filesystem::path("velox/parameters"));
+  dynamics_cfg = fsai::vehicle::VeloxVehicleDynamics::Config::FromVehicleConfig(vehicle_config_path,
+                                                                                dynamics_cfg);
+  const auto model_name = [model = dynamics_cfg.model]() {
+    switch (model) {
+      case velox::simulation::ModelType::MB: return "MB";
+      case velox::simulation::ModelType::ST: return "ST";
+      case velox::simulation::ModelType::STD: return "STD";
+    }
+    return "unknown";
+  }();
+  fsai::sim::log::Logf(fsai::sim::log::Level::kInfo,
+                       "Initializing Velox dynamics with model=%s vehicle_id=%d",
+                       model_name, dynamics_cfg.vehicle_id);
   fsai::vehicle::VeloxVehicleDynamics vehicle_dynamics(dynamics_cfg);
   // =============================
   // WORLD + VEHICLE DYNAMICS SECTION

--- a/sim/include/sim/vehicle/VeloxVehicleDynamics.hpp
+++ b/sim/include/sim/vehicle/VeloxVehicleDynamics.hpp
@@ -21,6 +21,9 @@ public:
         std::filesystem::path parameter_root{"velox/parameters"};
         velox::simulation::ModelType model{velox::simulation::ModelType::MB};
         int vehicle_id{1};
+
+        static Config FromVehicleConfig(const std::filesystem::path& vehicle_config,
+                                        Config base = Config{});
     };
 
     VeloxVehicleDynamics();

--- a/velox/parameters/vehicle/parameters_vehicle5.hpp
+++ b/velox/parameters/vehicle/parameters_vehicle5.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include "vehicle_parameters.hpp"
+
+namespace velox::models {
+
+/**
+ * Creates a VehicleParameters object holding all vehicle parameters for
+ * vehicle ID 5 (ADS-DV electric vehicle).
+ */
+inline VehicleParameters parameters_vehicle5(const std::string& dir_params = {})
+{
+    return setup_vehicle_parameters(5, dir_params);
+}
+
+} // namespace velox::models

--- a/velox/parameters/vehicle/parameters_vehicle5.yaml
+++ b/velox/parameters/vehicle/parameters_vehicle5.yaml
@@ -1,0 +1,83 @@
+# parameters_vehicle5 - ADS-DV electric vehicle parameter set
+#
+# These values approximate the lightweight ADS-DV EV platform using a
+# dynamic single-track model. Steering limits are aligned with the
+# control configuration in configs/vehicle/configDry.yaml.
+
+# vehicle body dimensions
+l: 2.0
+w: 1.4
+
+# steering constraints
+steering:
+  max: 0.3665191   # ~21 deg
+  min: -0.3665191
+  v_max: 1.0
+  v_min: -1.0
+  kappa_dot_max: 0.5
+  kappa_dot_dot_max: 10.0
+
+# longitudinal constraints
+longitudinal:
+  a_max: 7.5
+  j_max: 8000.0
+  j_dot_max: 15000.0
+  v_max: 35.0
+  v_min: -8.0
+  v_switch: 2.0
+
+# masses
+m: 225.0
+m_s: 200.0
+m_uf: 12.5
+m_ur: 12.5
+
+# axes distances
+# distances from sprung-mass CoG to front/rear axle
+# derived from the kinematic config (b_F/b_R)
+a: 0.869
+b: 0.711
+
+# moments of inertia of sprung mass
+I_Phi_s: 60.0
+I_y_s: 75.0
+I_z: 31.27
+I_xz_s: 0.0
+
+# suspension parameters
+K_sf: 18000.0
+K_sdf: 1200.0
+K_sr: 18000.0
+K_sdr: 1200.0
+
+# geometric parameters
+T_f: 1.2
+T_r: 1.2
+K_ras: 90000.0
+K_tsf: 0.0
+K_tsr: 0.0
+K_rad: 8000.0
+K_zt: 150000.0
+
+# center of gravity heights
+h_cg: 0.25
+h_raf: 0.0
+h_rar: 0.0
+h_s: 0.25
+
+# inertia / compliance / wheel radius
+I_uf: 2.0
+I_ur: 2.0
+I_y_w: 0.6
+K_lt: 1.0e-05
+R_w: 0.2525
+
+# torque split (unused by ST model but kept for completeness)
+T_sb: 0.55
+T_se: 0.5
+
+# suspension camber parameters
+D_f: 0.0
+D_r: 0.0
+E_f: 0.0
+E_r: 0.0


### PR DESCRIPTION
## Summary
- add ADS-DV EV vehicle parameters plus convenience header for vehicle ID 5
- extend VeloxVehicleDynamics configuration to load model/vehicle selection from vehicle configs and log the daemon init
- wire fsai_run to use the ADS-DV EV model/ID from configDry

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927258f20d88324a378662846b1a723)