### PR TITLE
Handle random track generation failures

### DIFF
--- a/sim/include/sim/World.hpp
+++ b/sim/include/sim/World.hpp
@@ -180,6 +180,7 @@ private:
     fsai::sim::MissionDefinition mission_{};
     TrackBuilderConfig trackBuilderConfig_{};
     TrackBuildResult trackState_{};
+    bool trackGenerationFailed_{false};
     CollisionService collisionService_{CollisionService::Config{}};
     ResetPolicy resetPolicy_{WorldControlConfig{}};
     fsai::sim::WorldRuntime runtime_{};

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <limits>
 #include <string>
+#include "logging.hpp"
 #include "fsai_clock.h"
 #include "World.hpp"
 #include "centerline.hpp"
@@ -162,6 +163,10 @@ void World::update(double dt) {
         return;
     }
 
+    if (trackGenerationFailed_) {
+        return;
+    }
+
     if (checkpointPositions.empty()) {
         std::printf("No checkpoints available. Resetting simulation.\n");
         const auto resetReason = fsai::sim::WorldRuntime::ResetReason::kTrackRegeneration;
@@ -313,12 +318,20 @@ void World::moveNextCheckpointToLast() {
 }
 
 void World::reset(const ResetDecision& decision) {
+    trackGenerationFailed_ = false;
     if (decision.regenerateTrack) {
         std::printf("Regenerating track due to reset.\n");
         if (mission_.trackSource == fsai::sim::TrackSource::kRandom) {
             mission_.track = {};
         }
-        trackState_ = buildTrackState();
+        try {
+            trackState_ = buildTrackState();
+        } catch (const std::exception& e) {
+            fsai::sim::log::LogWarning(
+                std::string("Track regeneration failed: ") + e.what());
+            trackGenerationFailed_ = true;
+            return;
+        }
     } else {
         std::printf("Resetting simulation without regenerating track.\n");
     }

--- a/sim/src/World.cpp
+++ b/sim/src/World.cpp
@@ -7,7 +7,7 @@
 #include <utility>
 #include <limits>
 #include <string>
-#include "logging.hpp"
+#include "../include/logging.hpp"
 #include "fsai_clock.h"
 #include "World.hpp"
 #include "centerline.hpp"

--- a/sim/src/world/TrackBuilder.cpp
+++ b/sim/src/world/TrackBuilder.cpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <string>
 
-#include "logging.hpp"
+#include "../../include/logging.hpp"
 #include "sim/mission/TrackCsvLoader.hpp"
 #include "cone_constants.hpp"
 #include "PathGenerator.hpp"
@@ -181,7 +181,7 @@ fsai::sim::TrackData TrackBuilder::generateRandomTrack() const {
     LogWarning("Random track generation failed after retries; using fallback CSV track");
     try {
         const std::filesystem::path fallbackPath{kFallbackRandomTrack};
-        fsai::sim::TrackResult track = fsai::sim::LoadTrackFromCsv(fallbackPath);
+        TrackResult track = fsai::sim::LoadTrackFromCsv(fallbackPath);
         fsai::sim::TrackData fallback = fsai::sim::TrackData::FromTrackResult(track);
         if (hasCheckpoints(fallback)) {
             return fallback;

--- a/sim/src/world/TrackBuilder.cpp
+++ b/sim/src/world/TrackBuilder.cpp
@@ -1,8 +1,12 @@
 #include "TrackBuilder.hpp"
 
 #include <algorithm>
+#include <filesystem>
 #include <stdexcept>
+#include <string>
 
+#include "logging.hpp"
+#include "sim/mission/TrackCsvLoader.hpp"
 #include "cone_constants.hpp"
 #include "PathGenerator.hpp"
 #include "TrackGenerator.hpp"
@@ -14,6 +18,7 @@ using fsai::sim::kLargeConeMassKg;
 using fsai::sim::kLargeConeRadiusMeters;
 using fsai::sim::kSmallConeMassKg;
 using fsai::sim::kSmallConeRadiusMeters;
+using fsai::sim::log::LogWarning;
 
 Vector3 transformToVector3(const Transform& t) {
     return {t.position.x, t.position.y, t.position.z};
@@ -51,6 +56,10 @@ CollisionSegment makeSegment(const Vector2& start, const Vector2& end, float rad
     return segment;
 }
 
+bool hasCheckpoints(const fsai::sim::TrackData& track) {
+    return !track.checkpoints.empty();
+}
+
 void rebuildConePositions(const std::vector<Cone>& cones, std::vector<Vector3>& positions) {
     positions.clear();
     positions.reserve(cones.size());
@@ -84,7 +93,8 @@ TrackBuildResult TrackBuilder::buildFromMission(
         track = SkidpadTrackStrategy{}.Rewrite(track);
     }
 
-    if (track.checkpoints.empty()) {
+    if (!hasCheckpoints(track)) {
+        LogWarning("MissionDefinition did not provide any checkpoints");
         throw std::runtime_error("MissionDefinition did not provide any checkpoints");
     }
 
@@ -149,10 +159,37 @@ TrackBuildResult TrackBuilder::buildFromTrackData(const fsai::sim::TrackData& tr
 }
 
 fsai::sim::TrackData TrackBuilder::generateRandomTrack() const {
-    PathConfig pathConfig = config_.pathConfig;
-    PathGenerator pathGen(pathConfig);
-    PathResult path = pathGen.generatePath(pathConfig.resolution);
-    TrackGenerator trackGen;
-    TrackResult track = trackGen.generateTrack(pathConfig, path);
-    return fsai::sim::TrackData::FromTrackResult(track);
+    constexpr int kMaxRandomAttempts = 3;
+    constexpr const char* kFallbackRandomTrack = "configs/tracks/rand.csv";
+
+    for (int attempt = 1; attempt <= kMaxRandomAttempts; ++attempt) {
+        PathConfig pathConfig = config_.pathConfig;
+        PathGenerator pathGen(pathConfig);
+        PathResult path = pathGen.generatePath(pathConfig.resolution);
+        TrackGenerator trackGen;
+        TrackResult track = trackGen.generateTrack(pathConfig, path);
+        fsai::sim::TrackData generated = fsai::sim::TrackData::FromTrackResult(track);
+        if (hasCheckpoints(generated)) {
+            return generated;
+        }
+
+        LogWarning("Random track generation produced no checkpoints; retrying (attempt " +
+                    std::to_string(attempt) + "/" +
+                    std::to_string(kMaxRandomAttempts) + ")");
+    }
+
+    LogWarning("Random track generation failed after retries; using fallback CSV track");
+    try {
+        const std::filesystem::path fallbackPath{kFallbackRandomTrack};
+        fsai::sim::TrackResult track = fsai::sim::LoadTrackFromCsv(fallbackPath);
+        fsai::sim::TrackData fallback = fsai::sim::TrackData::FromTrackResult(track);
+        if (hasCheckpoints(fallback)) {
+            return fallback;
+        }
+        LogWarning("Fallback CSV track contained no checkpoints");
+    } catch (const std::exception& e) {
+        LogWarning(std::string("Failed to load fallback CSV track: ") + e.what());
+    }
+
+    return {};
 }


### PR DESCRIPTION
## Summary
- Retry random track generation and fall back to a known CSV track when generation returns no checkpoints, logging warnings for failures
- Log warnings for empty mission track data and guard world updates after failed regeneration attempts
- Prevent reset loops by stopping further processing when track regeneration fails

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69272e9e03608324b9acaad49312fc02)